### PR TITLE
Add ability to include count value in add/update command

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,7 @@
         "indent": ["error", 4],
         "object-shorthand": ["error"],
         "no-console": ["error", { "allow": ["debug", "info", "warn", "error"] }],
-
+        "no-trailing-spaces": ["error"],
         // plugin:no-only-tests
         "no-only-tests/no-only-tests": "error"
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ FEATURES
 * Full flexibility & dynamic control. 
   * Ability to control via simple topic commands. Examples include...
     * remove, remove-all, remove-all-dynamic, remove-all-static, remove-active, remove-active-dynamic, remove-active-static, remove-inactive, remove-inactive-dynamic, remove-inactive-static
-    * list, list-all, list-all-dynamic, list-all-static, list-active, list-active-dynamic, list-active-static, list-inactive, list-inactive-dynamic, list-inactive-static
     * export, export-all, export-all-dynamic, export-all-static, export-active, export-active-dynamic, export-active-static, export-inactive, export-inactive-dynamic, export-inactive-static
+    * list, list-all, list-all-dynamic, list-all-static, list-active, list-active-dynamic, list-active-static, list-inactive, list-inactive-dynamic, list-inactive-static
     * status, status-all, status-all-dynamic, status-all-static, status-active, status-active-dynamic, status-active-static, status-inactive, status-inactive-dynamic, status-inactive-static
+      * status is an alias for list
     * stop, stop-all, stop-all-dynamic, stop-all-static
     * start, start-all, start-all-dynamic, start-all-static
     * pause, pause-all, pause-all-dynamic, pause-all-static

--- a/cronplus.html
+++ b/cronplus.html
@@ -2970,7 +2970,7 @@ msg.payload = "name"; //  name of the schedule</code></pre>
         </dd>
         <dd>GENERAL NOTES...<br>
             <ul>
-                <li>Adding a schedule with the same name as an existing schedule will replace the existing one</li>
+                <li>Adding a schedule with the same name as an existing schedule will update the existing one. If the task is finished (count has reached limit) its count will not be reset and it will not be restarted automatically unless the "add"/"update" command options include the flag <code>resetCounter: true</code></li>
                 <li>Adding a schedule with property <code>"limit":3</code> will cause that schedule to be stopped after the third trigger. It can be started again by injecting a payload of <code>{"command":"start" "name": "schedule name"}</code></li>
                 <li>Static (UI added) schedules can be also be updated by using the name specified in the UI</li>
                 <li>When a cron-plus-plus node is modified and deployed (or node-red is restarted), dynamic entries are discarded and must be injected again</li>

--- a/cronplus.html
+++ b/cronplus.html
@@ -2787,7 +2787,8 @@ function onSchedulesExpandCompress () {
     "expression": "*/6 * * * * * *",
     "expressionType": "cron",
     "payloadType": "default",
-    "limit": 3
+    "limit": 3,
+    "count": 0, // [optional] can be used to init the task run count
   },
   {
     "command": "add",
@@ -2970,7 +2971,8 @@ msg.payload = "name"; //  name of the schedule</code></pre>
         </dd>
         <dd>GENERAL NOTES...<br>
             <ul>
-                <li>Adding a schedule with the same name as an existing schedule will update the existing one. If the task is finished (count has reached limit) its count will not be reset and it will not be restarted automatically unless the "add"/"update" command options include the flag <code>resetCounter: true</code></li>
+                <li>Adding a schedule with the same name as an existing schedule will update the existing one.</li>
+                <li>If the task being updated has a limit and it is finished (count has reached limit) its count will not be reset and it will not be restarted automatically unless the "add"/"update" command options include the <code>count</code> property with a value less than the current limit</li>
                 <li>Adding a schedule with property <code>"limit":3</code> will cause that schedule to be stopped after the third trigger. It can be started again by injecting a payload of <code>{"command":"start" "name": "schedule name"}</code></li>
                 <li>Static (UI added) schedules can be also be updated by using the name specified in the UI</li>
                 <li>When a cron-plus-plus node is modified and deployed (or node-red is restarted), dynamic entries are discarded and must be injected again</li>

--- a/cronplus.html
+++ b/cronplus.html
@@ -2299,11 +2299,11 @@ function onSchedulesExpandCompress () {
 
         .cron-select-period select,
         .cron-input select,
-        .cron-input input[type=radio], 
+        .cron-input input[type=radio],
         .cron-input input[type=checkbox] {
             margin-left: 5px;
             margin-right: 5px;
-        }        
+        }
 
         table.cron-plus-table {
             border: solid 1px var(--red-ui-secondary-background);
@@ -2452,14 +2452,14 @@ function onSchedulesExpandCompress () {
             padding: 1rem;
             border-radius: 4px;
         }
-    </style>  
+    </style>
 
     <div id="cron-plus-map-dialog" style="display: none;" title="Choose location...">
         <div class="cron-plus-map-loading" >
             <h3>Attempting to load map... <i class="fa fa-spinner fa-spin" style="font-size:24px"></i></h3>
             <p>The interactive Map is loaded via CDN at client side (to minimise installation size) and therefore requires an internet connection. Please wait 1 moment.</p>
             <h4>Alternative ways to get coordinates...</h4>
-            <ul> 
+            <ul>
                 <li>Visit <a href="https://www.latlong.net/" target="_blank" rel="noopener noreferrer">www.latlong.net</a> (on another device if required) then copy the "Lat Long" value provided into the cron-plus coordinates box</li>
                 <li>Visit google maps, MSN maps, almost any other maps website on another device to get GPS or longitude latitude value</li>
                 <li>Try one of the many longitude latitude apps available in the app store on your mobile phone</li>
@@ -2467,19 +2467,19 @@ function onSchedulesExpandCompress () {
                 <li>Use a topographic map</li>
                 <li>Ask a friend</li>
             </ul>
-            <h4>Accepted formats...</h4> 
+            <h4>Accepted formats...</h4>
             <ul>
                 <li>Decimal Degrees E.g: <code class="cron-plus-coordinates">54.9992500,-1.4170300</code> or <code class="cron-plus-coordinates">54.9992500° N 1.4170300° W</code></li>
                 <li>Degrees Minutes Seconds E.g: <code class="cron-plus-coordinates">54° 59' 57.3'' N 1° 25' 1.308'' W</code></li>
                 <li>Decimal Minutes E.g: <code class="cron-plus-coordinates">54° 59.955' , -1° 25.0218'</code></li>
                 <li>GPS E.g: <code class="cron-plus-coordinates">N54°59'57.3, W1°25'1.308"</code>, <code class="cron-plus-coordinates">54°59'57.3"N, 1°25'1.308"W</code>, <code class="cron-plus-coordinates">54d 59' 57" N 1d 25' 1" W</code> or <code class="cron-plus-coordinates">54:59:57.3N 1:25:1.308W</code></li>
-            </ul>    
+            </ul>
         </div>
         <div class="cron-plus-map-not-loaded"  style="display:hidden" >
             <h3>No internet on this device?</h3>
             <p>The interactive Map is loaded via CDN at client side (to minimise installation size) and therefore requires an internet connection. As you are seeing this message, it is likely this device does not have access to the internet.</p>
             <h4>Alternative ways to get coordinates...</h4>
-            <ul> 
+            <ul>
                 <li>Visit <a href="https://www.latlong.net/" target="_blank" rel="noopener noreferrer">www.latlong.net</a> (on another device if required) then copy the "Lat Long" value provided into the cron-plus coordinates box</li>
                 <li>Visit google maps, MSN maps, almost any other maps website on another device to get GPS or longitude latitude value</li>
                 <li>Try one of the many longitude latitude apps available in the app store on your mobile phone</li>
@@ -2546,7 +2546,7 @@ function onSchedulesExpandCompress () {
         <!-- Row 1 -->
         <div style="display: flex; justify-content: space-between;">
             <label for="node-input-option-container-div" style="vertical-align:top;flex-basis: 120px;">
-                <i class="fa fa-list-alt"></i> 
+                <i class="fa fa-list-alt"></i>
                 Schedules
             </label>
             <div style="flex-grow: 1; column-gap: 2px; margin-bottom: 2px; margin-top: 0px; display: flex; padding: 0px 0px 0px 4px;">
@@ -2613,11 +2613,11 @@ function onSchedulesExpandCompress () {
             A timezone to use. Leave blank for system timezone. Alternatively, enter UTC or a timezone in the format of Region/Area (<a target="_blank" href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">list</a>)
             <br>
             TIP: Timezone should be perceived from your own perspective. See the <a href="#understanding-timezone">Understanding Timezone</a> example below.
-        </div>    
+        </div>
         <h4>Location (optional)</h4>
         <div style="padding-left: 15px">
             Here you can chose to set a common location for all solar events (optional)
-        </div>    
+        </div>
         <h4>Outputs</h4>
         <div style="padding-left: 15px">
             <ul>
@@ -2625,7 +2625,7 @@ function onSchedulesExpandCompress () {
                 <li>2 outputs: Schedule messages to output 1, command responses to output 2</li>
                 <li>Fan out: Separate outputs for static, dynamic and command messages</li>
             </ul>
-        </div>    
+        </div>
         <h4>Persist dynamic schedules</h4>
         <div style="padding-left: 15px">
             Enabling this option causes dynamic schedules to be saved to file and re-loaded when the cron-plus node is loaded or re-deployed. <br>
@@ -2634,7 +2634,7 @@ function onSchedulesExpandCompress () {
                 <li>Any time an update to any dynamic schedule occurs, all dynamic schedules are saved to file</li>
                 <li>The schedules are saved in a directory called <code>cronplusdata</code> under your node-red folder</li>
             </ul>
-        </div>    
+        </div>
         <h4>Schedules</h4>
         <div style="padding-left: 15px">
             A table of schedules. Entries here are considered static and will be reloaded when node-red starts or the cron-plus node is (re)deployed.
@@ -2684,7 +2684,7 @@ function onSchedulesExpandCompress () {
                 <li><code>L</code> Short-hand for "last" and is allowed for the day-of-month and day-of-week fields. The "L" character has a different meaning in each of the two fields. For example, "L" in the day-of-month field means the last day of the month. If used in the day-of-week field, it means 7 or SAT. However, if used in the day-of-week field after another value, it means the last xxx day of the month. For example, "6L" in the day-of-week field means the last Friday of the month</li>
                 <li><code>W</code> Short-hand for "weekday" and is allowed for the day-of-month field. The "W" character is used to specify the weekday nearest the given day. For example, "15W" in the day-of-month field means the nearest weekday to the 15th of the month. Therefore, if the 15th is a Saturday, the job runs on Friday the 14th. The "L" and "W" characters can be combined in the day-of-month field. For example, "LW" means the last weekday of the month.</li>
                 <li><code>#</code> Hash marks specify constructs. For example, "6#3' in the day-of-week field means the third Friday of the month.</li>
-            </ul>        
+            </ul>
             <p>Examples...</p>
             <ul>
                 <li><code>* * * * * *</code> Every Second</li>
@@ -2740,12 +2740,12 @@ function onSchedulesExpandCompress () {
                 <li>Decimal Minutes E.g: <code class="cron-plus-coordinates">54° 59.955' , -1° 25.0218'</code></li>
                 <li>GPS E.g: <code class="cron-plus-coordinates">N54°59'57.3, W1°25'1.308"</code>, <code class="cron-plus-coordinates">54°59'57.3"N, 1°25'1.308"W</code>, <code class="cron-plus-coordinates">54d 59' 57" N 1d 25' 1" W</code> or <code class="cron-plus-coordinates">54:59:57.3N 1:25:1.308W</code></li>
             </ul>
-        </div>        
+        </div>
         <h4>Schedules - Offset</h4>
         <div style="padding-left: 15px">
             <i>NOTE: Only displayed when the type is set to <b>solar events</b></i><br>
             The offset field can be used to add a positive or negative offset in minutes to the sunrise or sunset time.
-        </div>        
+        </div>
 
     </dl>
     <h3>Output</h3>
@@ -2760,7 +2760,7 @@ function onSchedulesExpandCompress () {
     <h3>Inputs <i>(Advanced Usage)</i></h3>
     <dl class="message-properties">
         <dt><i>topic</i> <span class="property-type">string</span></dt>
-        <dd>Most of the commands can be provided in the topic with the name of schedule in the payload (where appropriate). <br>Supported command topics... 
+        <dd>Most of the commands can be provided in the topic with the name of schedule in the payload (where appropriate). <br>Supported command topics...
                     <ul>
                         <li>trigger</li>
                         <li>status</li>
@@ -2787,7 +2787,7 @@ function onSchedulesExpandCompress () {
     "expression": "*/6 * * * * * *",
     "expressionType": "cron",
     "payloadType": "default",
-    "limit": 3 
+    "limit": 3
   },
   {
     "command": "add",
@@ -2809,7 +2809,7 @@ function onSchedulesExpandCompress () {
     "limit": null
   }
 ]</code></pre>
-                
+
                 <p><i>Details...</i><br>
                     Adding a CRON expression
                     <ul>
@@ -2908,29 +2908,29 @@ msg.payload = "name"; //  name of the schedule</code></pre>
                     <pre class="cron-plus-code"><code>msg: {
   "topic": "trigger",
   "payload": "schedule1"
-}</code></pre>                    
+}</code></pre>
                     Example : Using a simple topic command to export all dynamically added schedules...<br>
                     <pre class="cron-plus-code"><code>msg: {
   "topic": "export-all-dynamic"
-}</code></pre>                    
+}</code></pre>
                     Example : Using a simple topic command to delete a schedule named "schedule1"<br>
                     <pre class="cron-plus-code"><code>msg: {
   "topic": "remove",
   "payload": "schedule1"
-}</code></pre>                    
+}</code></pre>
                     Example : Using a cmd payload to pause all schedules...<br>
                     <pre class="cron-plus-code"><code>payload: {
   "command": "pause-all"
-}</code></pre> 
+}</code></pre>
                     Example : Using a simple topic command to delete all dynamic schedules that have finished <br>
                     <pre class="cron-plus-code"><code>msg: {
   "topic": "remove-inactive-dynamic"
-}</code></pre>                    
+}</code></pre>
                 </p>
             </p>
             </p>
 
-                 
+
 
             <p><b>Describe</b><br>
                 Example : cmd payload to describe a cron expression...<br>
@@ -2966,7 +2966,7 @@ msg.payload = "name"; //  name of the schedule</code></pre>
                         <li>timeZone: (string|optional) A timezone to use. Leave blank for system timezone. Alternatively, enter UTC or a timezone in the format of Region/Area (<a target="_blank" href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">list</a>) </li>
                     </ul>
                 </p>
-            </p>                
+            </p>
         </dd>
         <dd>GENERAL NOTES...<br>
             <ul>
@@ -3016,7 +3016,7 @@ msg.payload = "name"; //  name of the schedule</code></pre>
                     <li>Field 2 (topic)     : Enter &quot;stocks/nyse/trading&quot;</li>
                     <li>Field 3 (payload)   : Select boolean - true</li>
                     <li>Field 4 (type)      : Select &quot;cron&quot;</li>
-                    <li>Field 5 (expression): Enter the expression <code>0 30 9 * * 1-5</code></li>                    
+                    <li>Field 5 (expression): Enter the expression <code>0 30 9 * * 1-5</code></li>
                 </ul>
             </li>
             <li>Add a new schedule...
@@ -3028,9 +3028,9 @@ msg.payload = "name"; //  name of the schedule</code></pre>
                     <li>Field 5 (expression): Enter the expression <code>0 0 16 * * 1-5</code></li>
                 </ul>
             </li>
-        </ul>  
-        
-        <p></p>         
+        </ul>
+
+        <p></p>
 
         <h4><b>Example 2...</b></h4>
         <p>Get an reminder (in Moscow) to call my wife 30 mins after the sun rises in Cairo.</p>
@@ -3072,8 +3072,8 @@ msg.payload = "name"; //  name of the schedule</code></pre>
                     <li>Field 7 (offset)  : Enter an offset of 30 (allow her time to make a coffee)</li>
                 </ul>
             </li>
-        </ul>   
+        </ul>
 
     </dl>
-    
+
 </script>

--- a/cronplus.js
+++ b/cronplus.js
@@ -1514,7 +1514,13 @@ module.exports = function (RED) {
                 let opCount = 0; let modified = false
                 if (task) {
                     modified = true
-                    opCount = task.node_count || 0
+                    opCount = (task.node_count || 0)
+                    // if this is an update or add command, then we will observe resetCounter flag
+                    // msg is only present when it is a user command
+                    if (msg && opt.resetCounter === true) {
+                        opCount = 0
+                    }
+                    opt.count = opCount
                     deleteTask(node, opt.name)
                 }
                 const taskCount = node.tasks ? node.tasks.length : 0
@@ -1620,7 +1626,9 @@ module.exports = function (RED) {
                     requestSerialisation()// request persistent state be written
                 })
             task.stop()// prevent bug where calling start without first calling stop causes events to bunch up
-            if (opt.dontStartTheTask !== true) {
+            if (opt.dontStartTheTask === true || isTaskFinished(task)) {
+                // do not start the task
+            } else {
                 task.start()
             }
             node.tasks.push(task)

--- a/cronplus.js
+++ b/cronplus.js
@@ -1515,10 +1515,8 @@ module.exports = function (RED) {
                 if (task) {
                     modified = true
                     opCount = (task.node_count || 0)
-                    // if this is an update or add command, then we will observe resetCounter flag
-                    // msg is only present when it is a user command
-                    if (msg && opt.resetCounter === true) {
-                        opCount = 0
+                    if (Object.prototype.hasOwnProperty.call(opt, 'count') && typeof opt.count === 'number' && opt.count >= 0) {
+                        opCount = opt.count
                     }
                     opt.count = opCount
                     deleteTask(node, opt.name)
@@ -1577,7 +1575,6 @@ module.exports = function (RED) {
             task.node_expression = opt.expression
             task.node_payloadType = opt.payloadType
             task.node_payload = opt.payload
-            task.node_count = opt.count || 0
             task.node_locationType = opt.locationType
             task.node_location = opt.location
             task.node_solarType = opt.solarType
@@ -1585,7 +1582,11 @@ module.exports = function (RED) {
             task.node_offset = opt.offset
             task.node_index = index
             task.node_opt = opt
-            task.node_limit = opt.limit || 0
+            task.node_limit = typeof opt.limit === 'number' ? opt.limit : 0
+            task.node_count = typeof opt.count === 'number' ? opt.count : 0
+            if (task.node_limit > 0 && task.node_count > task.node_limit) {
+                task.node_count = task.node_limit
+            }
             task.stop()
             task.on('run', (timestamp) => {
                 node.debug(`running '${task.name}' ~ '${task.node_topic}'\n now time ${new Date()}\n crontime ${new Date(timestamp)}`)

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -236,7 +236,7 @@ describe('cron-plus Node', function () {
             completeHelper = null
         })
 
-        function createAddScheduleMsg ({ name = 'dynCron', topic = 'dynCron', expression = '0 0 * * * * *', expressionType = 'cron', payloadType = 'default', limit = 1 }) {
+        function createAddScheduleMsg ({ name = 'dynCron', topic = 'dynCron', expression = '0 0 * * * * *', expressionType = 'cron', payloadType = 'default', limit = 1, resetCounter = false }) {
             return {
                 payload: {
                     command: 'add',
@@ -245,7 +245,8 @@ describe('cron-plus Node', function () {
                     expression,
                     expressionType,
                     payloadType,
-                    limit
+                    limit,
+                    resetCounter
                 }
             }
         }
@@ -819,6 +820,80 @@ describe('cron-plus Node', function () {
             // after waiting another second, dyn-1 should have triggered 3 times and should have reached its limit & stopped
             commandChecker(messages[3], { description: 'check status of inactive schedules should be 1', send: { topic: 'status-inactive', payload: '' }, expected: { command: 'status-inactive', scheduleCount: 1 } })
             countChecker('dyn-1', messages[3].payload.result[0], 3, 3, false) // dyn-1 should have triggered 3 times and should NOT be running
+        })
+        it('should not reset count when finished schedule is updated (default behaviour)', async function () {
+            this.timeout(7000)
+            // setup add dyn-1
+            testNode.receive(createAddScheduleMsg({ name: 'dyn-1', limit: 1, expression: '* * * * * * *' })) // every 1 seconds
+
+            const messages = []
+            const resultPromise = new Promise(resolve => {
+                helperNode5.on('input', (msg) => {
+                    messages.push(msg)
+                    if (messages.length >= 3) {
+                        resolve()
+                    }
+                })
+            })
+
+            testNode.receive({ topic: 'status-active', payload: '' }) // check status of active schedules before stopping
+            await sleep(1100) // wait 1
+            testNode.receive({ topic: 'status-inactive', payload: '' }) // check status of inactive schedules before stopping
+            // replace dyn-1 with a new one
+            testNode.receive(createAddScheduleMsg({ name: 'dyn-1', limit: 1, expression: '* * * * * * *', topic: 'dyn-1-update' })) // every 1 seconds
+            testNode.receive({ topic: 'status-all', payload: '' }) // check status of all schedules before stopping
+
+            await resultPromise
+            messages.should.have.length(3)
+            // at first, dyn-1 should be active
+            commandChecker(messages[0], { description: 'check status of active schedules should be 4', send: { topic: 'status-active', payload: '' }, expected: { command: 'status-active', scheduleCount: 4 } })
+            countChecker('dyn-1', messages[0].payload.result[3], 1, 0, true) // dyn-1 should have triggered 0 times
+            // after waiting 1 second, dyn-1 should have triggered 1 time and should be no longer be running
+            commandChecker(messages[1], { description: 'check status of inactive schedules should be 1', send: { topic: 'status-inactive', payload: '' }, expected: { command: 'status-inactive', scheduleCount: 1 } })
+            countChecker('dyn-1', messages[1].payload.result[0], 1, 1, false) // dyn-1 should have triggered 1 time and should NOT be running
+            // after replacing dyn-1, it should be active again
+            const dyn1 = messages[2].payload.result.find(s => s.config.name === 'dyn-1')
+            should.exist(dyn1, 'dyn-1 should be in the result')
+            dyn1.should.have.property('status').which.is.an.Object()
+            dyn1.status.should.have.property('count', 1)
+            dyn1.status.should.have.property('isRunning', false)
+        })
+        it('should reset count when finished schedule is updated (when resetCounter is true)', async function () {
+            this.timeout(7000)
+            // setup add dyn-1
+            testNode.receive(createAddScheduleMsg({ name: 'dyn-1', limit: 1, expression: '* * * * * * *' })) // every 1 seconds
+
+            const messages = []
+            const resultPromise = new Promise(resolve => {
+                helperNode5.on('input', (msg) => {
+                    messages.push(msg)
+                    if (messages.length >= 3) {
+                        resolve()
+                    }
+                })
+            })
+
+            testNode.receive({ topic: 'status-active', payload: '' }) // check status of active schedules before stopping
+            await sleep(1100) // wait 1
+            testNode.receive({ topic: 'status-inactive', payload: '' }) // check status of inactive schedules before stopping
+            // replace dyn-1 with a new one
+            testNode.receive(createAddScheduleMsg({ name: 'dyn-1', limit: 1, expression: '* * * * * * *', resetCounter: true, topic: 'dyn-1-update' })) // every 1 seconds
+            testNode.receive({ topic: 'status-all', payload: '' }) // check status of all schedules before stopping
+
+            await resultPromise
+            messages.should.have.length(3)
+            // at first, dyn-1 should be active
+            commandChecker(messages[0], { description: 'check status of active schedules should be 4', send: { topic: 'status-active', payload: '' }, expected: { command: 'status-active', scheduleCount: 4 } })
+            countChecker('dyn-1', messages[0].payload.result[3], 1, 0, true) // dyn-1 should have triggered 0 times
+            // after waiting 1 second, dyn-1 should have triggered 1 time and should be no longer be running
+            commandChecker(messages[1], { description: 'check status of inactive schedules should be 1', send: { topic: 'status-inactive', payload: '' }, expected: { command: 'status-inactive', scheduleCount: 1 } })
+            countChecker('dyn-1', messages[1].payload.result[0], 1, 1, false) // dyn-1 should have triggered 1 time and should NOT be running
+            // after replacing dyn-1, it should be active again
+            const dyn1 = messages[2].payload.result.find(s => s.config.name === 'dyn-1')
+            should.exist(dyn1, 'dyn-1 should be in the result')
+            dyn1.should.have.property('status').which.is.an.Object()
+            dyn1.status.should.have.property('count', 0)
+            dyn1.status.should.have.property('isRunning', true)
         })
         // test dynamic capabilities
         it('should add a schedule dynamically', async function () {


### PR DESCRIPTION
To permit an updated schedule to be restarted, the count can now be included in the command

* Allow `count` to be applied on add/update command
* Added 2 tests to verify this
* Update built in docs to make this clear

e.g. 

```
msg.payload =  { command: "add", name: 'dyn-1', limit: 1, count: 0, ... }
```

This enables the user to set/update the count to `0` effectively restarting a finished task

closes #78  