### PR TITLE
fix: prevent infinite loop when a cron schedule can never occur

### DIFF
--- a/cronplus.js
+++ b/cronplus.js
@@ -213,6 +213,26 @@ function isDateSequence (data) {
 }
 
 /**
+ * Guards against a cronosjs bug where an expression that can never occur
+ * (e.g. `0 0 30 2 *` - 30th of February) causes `nextDate()` to search year
+ * by year forever, locking up the event loop. An unbounded (`*`) year field
+ * never runs out of candidate years, so the search never terminates.
+ * Cron date/day patterns repeat within the 400 year Gregorian cycle, so if
+ * no occurrence exists within 500 years the expression will never fire -
+ * `nextDate()` then returns `null`, which is already handled as "Never".
+ * @param {cronosjs.CronosExpression} ex a parsed cron expression
+ * @returns {cronosjs.CronosExpression} the same expression, with the year scan bounded
+ */
+function limitExpressionYearScan (ex) {
+    if (ex && ex.years && typeof ex.years.nextYear === 'function') {
+        const maxYear = new Date().getFullYear() + 500
+        const nextYear = ex.years.nextYear.bind(ex.years)
+        ex.years.nextYear = fromYear => (fromYear > maxYear) ? null : nextYear(fromYear)
+    }
+    return ex
+}
+
+/**
  * Returns an object describing the parameters.
  * @param {string} expression The expressions or coordinates to use
  * @param {string} expressionType The expression type ("cron" | "solar" | "dates")
@@ -308,7 +328,7 @@ function _describeExpression (expression, expressionType, timeZone, offset, sola
     }
 
     if (exOk) {
-        const ex = cronosjs.CronosExpression.parse(expression, cronOpts)
+        const ex = limitExpressionYearScan(cronosjs.CronosExpression.parse(expression, cronOpts))
         const next = ex.nextDate()
         if (next) {
             const ms = next.valueOf() - now.valueOf()
@@ -1582,7 +1602,7 @@ module.exports = function (RED) {
             const cronOpts = node.timeZone ? { timezone: node.timeZone } : undefined
             let task
             if (opt.expressionType === 'cron') {
-                const expression = cronosjs.CronosExpression.parse(opt.expression, cronOpts)
+                const expression = limitExpressionYearScan(cronosjs.CronosExpression.parse(opt.expression, cronOpts))
                 task = new cronosjs.CronosTask(expression)
             } else if (opt.expressionType === 'solar') {
                 if (node.defaultLocationType === 'env' || node.defaultLocationType === 'fixed') {

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -102,6 +102,34 @@ describe('cron-plus Node', function () {
         })
     })
 
+    it('should not hang when a schedule can never occur (e.g. 30th of February)', { timeout: 5000 }, function (t, done) {
+        // cronosjs searches year-by-year for the next occurrence; an impossible date
+        // with an unbounded year field made that search spin forever, locking up the
+        // runtime on deploy. The year scan is now bounded and reports "Never".
+        const flow = [
+            { id: 't1n5', type: 'cronplus', name: 'never', outputField: 'payload', timeZone: '', persistDynamic: false, commandResponseMsgOutput: 'output1', outputs: 1, options: [{ name: 'schedule1', topic: 'schedule1', payloadType: 'default', payload: '', expressionType: 'cron', expression: '0 0 30 02 *', location: '', offset: '0' }], wires: [['t1n6']] },
+            { id: 't1n6', type: 'helper' }
+        ]
+        helper.load(cronplusNode, flow, function () {
+            // reaching this callback at all proves deploy did not lock the event loop
+            const t1n5 = helper.getNode('t1n5')
+            const t1n6 = helper.getNode('t1n6')
+            t1n6.on('input', function (msg) {
+                try {
+                    msg.should.have.property('payload').which.is.an.Object()
+                    msg.payload.should.have.property('result').which.is.an.Object()
+                    msg.payload.result.should.have.property('description').which.is.a.String()
+                    msg.payload.result.should.have.property('prettyNext', 'Never')
+                    done()
+                } catch (err) {
+                    done(err)
+                }
+            })
+            // also exercise the describe path with the impossible expression
+            t1n5.receive({ payload: { command: 'describe', expressionType: 'cron', expression: '0 0 30 02 *' } })
+        })
+    })
+
     const getObjectProperty = function (object, path, defaultValue) {
         return path
             // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
An impossible date expression (e.g. `0 0 30 02 *` - 30th of February) caused the runtime to lock up on deploy with 100% CPU. cronosjs searches year-by-year for the next occurrence, and an unbounded (`*`) year field never runs out of candidate years, so the search never terminates.

Bound the year scan to 500 years from now at both CronosExpression.parse call sites (describe and task creation). Cron date/day patterns repeat within the 400 year Gregorian cycle, so an expression with no occurrence inside 500 years can never fire - nextDate() then returns null, which is already handled and reported as "Never".

Adds a regression test that deploys a 30th-Feb schedule and verifies the describe command responds with prettyNext "Never" (the test hangs without the fix).

closes #110