### PR TITLE
fix: handle DST transitions using Debian cron conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ FEATURES
   * change detection can now be customised by adding an entry in `settings.js` or an environment variable named `CRONPLUS_MAX_CLOCK_DIFF` (as of V2.0.0)
 * Demo flows demonstrating many of the capabilities. Import via node-red menu > import > examples.
 * Optional time zone setting supporting UTC and Region/Area (e.g. Europe/London)
+* Daylight Saving Time transitions are handled following the same conventions as Debian cron (see below)
+
+Daylight Saving Time (DST) handling
+-----------------------------------
+
+When a schedule runs in a time zone that observes DST (either the node's time zone setting or the system time zone), cron-plus follows the same conventions as [Debian cron](https://blog.healthchecks.io/2021/10/how-debian-cron-handles-dst-transitions/):
+
+* A schedule is a **wildcard job** when its minute or hour field starts with `*` (e.g. `0,15,30,45 * * * * * *` "every 15 seconds", or `0 * 1 * * *` "every minute during the 1am hour"). Wildcard jobs maintain their real-time interval across a DST transition:
+  * when clocks go back, they also run during the repeated hour
+  * when clocks go forward, they continue at the next real-time slot
+* A schedule is a **fixed-time job** when both its minute and hour fields are specific (e.g. `0 30 1 * * *` "01:30 every day"). Fixed-time jobs:
+  * run only once when clocks go back and their scheduled time occurs twice
+  * run as soon as possible after the transition when clocks go forward and their scheduled time is skipped
+
+> [!TIP]
+> schedules using the `UTC` time zone (or any time zone without DST) are unaffected by DST transitions.
 
 Install
 -------

--- a/cronplus.js
+++ b/cronplus.js
@@ -233,6 +233,29 @@ function limitExpressionYearScan (ex) {
 }
 
 /**
+ * Classifies a cron expression the same way Debian cron does for DST
+ * handling: a job is a "wildcard job" when its minute or hour field starts
+ * with `*` (e.g. `0 0,15,30,45 * * * *` or `0 * 1 * * *`), otherwise it is a
+ * "fixed-time job" (e.g. `0 30 1 * * *`).
+ * Wildcard jobs maintain their real-time interval across a DST transition,
+ * so when clocks go back they must also run during the repeated hour.
+ * Fixed-time jobs must run only once in the repeated hour.
+ * See https://blog.healthchecks.io/2021/10/how-debian-cron-handles-dst-transitions/
+ * @param {string} expression cron expression (5, 6 or 7 fields, or @macro)
+ * @returns {boolean} true if the minute or hour field is a wildcard
+ */
+function isWildcardCronJob (expression) {
+    const expr = String(expression || '').trim().toLowerCase()
+    if (expr.startsWith('@')) {
+        return expr === '@hourly' // the only supported macro without a fixed hour + minute
+    }
+    const fields = expr.split(/\s+/g)
+    // cronosjs fields: 5 = `min hr dom mon dow`, 6/7 = `sec min hr dom mon dow [year]`
+    const [minute, hour] = fields.length === 5 ? [fields[0], fields[1]] : [fields[1], fields[2]]
+    return (hour || '').startsWith('*') || (minute || '').startsWith('*')
+}
+
+/**
  * Returns an object describing the parameters.
  * @param {string} expression The expressions or coordinates to use
  * @param {string} expressionType The expression type ("cron" | "solar" | "dates")
@@ -328,8 +351,8 @@ function _describeExpression (expression, expressionType, timeZone, offset, sola
     }
 
     if (exOk) {
-        const ex = limitExpressionYearScan(cronosjs.CronosExpression.parse(expression, cronOpts))
-        const next = ex.nextDate()
+        const ex = limitExpressionYearScan(cronosjs.CronosExpression.parse(expression, { ...cronOpts, skipRepeatedHour: !isWildcardCronJob(expression) }))
+        const next = ex.nextDate(now)
         if (next) {
             const ms = next.valueOf() - now.valueOf()
             result.prettyNext = `in ${prettyMs(ms, { secondsDecimalDigits: 0, verbose: true })}`
@@ -1602,7 +1625,7 @@ module.exports = function (RED) {
             const cronOpts = node.timeZone ? { timezone: node.timeZone } : undefined
             let task
             if (opt.expressionType === 'cron') {
-                const expression = limitExpressionYearScan(cronosjs.CronosExpression.parse(opt.expression, cronOpts))
+                const expression = limitExpressionYearScan(cronosjs.CronosExpression.parse(opt.expression, { ...cronOpts, skipRepeatedHour: !isWildcardCronJob(opt.expression) }))
                 task = new cronosjs.CronosTask(expression)
             } else if (opt.expressionType === 'solar') {
                 if (node.defaultLocationType === 'env' || node.defaultLocationType === 'fixed') {

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -130,6 +130,95 @@ describe('cron-plus Node', function () {
         })
     })
 
+    describe('DST transition handling (Debian cron rules)', function () {
+        // Jobs whose minute or hour field starts with `*` ("wildcard jobs") keep
+        // their real-time interval across a DST change, so they also run during
+        // the repeated hour when clocks go back. Jobs with a fixed hour + minute
+        // ("fixed-time jobs") run only once in a repeated hour, and run as soon
+        // as possible after a missing hour when clocks go forward.
+        // Ref: https://blog.healthchecks.io/2021/10/how-debian-cron-handles-dst-transitions/
+        // MockTimers' 'Date' api landed in Node 20.11.0 - earlier versions throw on enable()
+        const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(Number)
+        const hasMockDate = nodeMajor > 20 || (nodeMajor === 20 && nodeMinor >= 11)
+        const iso = d => new Date(d).toISOString()
+
+        // loads a cronplus node and returns a function that asks it to describe
+        // a cron expression at a fixed point in time (Europe/London)
+        const loadDescriber = async () => {
+            const flow = [
+                { id: 'dst1', type: 'cronplus', name: 'dst', outputField: 'payload', timeZone: 'Europe/London', persistDynamic: false, commandResponseMsgOutput: 'output1', outputs: 1, options: [{ name: 'schedule1', topic: 'schedule1', payloadType: 'default', payload: '', expressionType: 'cron', expression: '0 0 * * * * 2000', location: '', offset: '0' }], wires: [['dst2']] },
+                { id: 'dst2', type: 'helper' }
+            ]
+            await helper.load(cronplusNode, flow)
+            const dst1 = helper.getNode('dst1')
+            const dst2 = helper.getNode('dst2')
+            return (expression, time) => new Promise(resolve => {
+                dst2.once('input', msg => resolve(msg.payload.result))
+                dst1.receive({ payload: { command: 'describe', expressionType: 'cron', expression, timeZone: 'Europe/London', time } })
+            })
+        }
+
+        // UK fall back: Sun 26 Oct 2025, 02:00 BST -> 01:00 GMT (01:00-01:59 local occurs twice)
+        it('wildcard schedule should keep running through the repeated hour (clocks go back)', async function () {
+            const describeExpr = await loadDescriber()
+            const result = await describeExpr('0,15,30,45 * * * * * *', '2025-10-26T00:59:50Z') // 01:59:50 BST
+            iso(result.nextDate).should.eql('2025-10-26T01:00:00.000Z') // 01:00:00 GMT, second pass of the repeated hour
+        })
+        it('minute-wildcard schedule with fixed hour is a wildcard job (clocks go back)', async function () {
+            const describeExpr = await loadDescriber()
+            const result = await describeExpr('0 * 1 * * * *', '2025-10-26T00:59:30Z') // 01:59:30 BST
+            iso(result.nextDate).should.eql('2025-10-26T01:00:00.000Z') // hour 1 repeats - runs again
+        })
+        it('fixed-time schedule should run only once in the repeated hour (clocks go back)', async function () {
+            const describeExpr = await loadDescriber()
+            const first = await describeExpr('0 30 1 * * * *', '2025-10-26T00:29:00Z') // 01:29 BST
+            iso(first.nextDate).should.eql('2025-10-26T00:30:00.000Z') // 01:30 BST, first pass runs
+            const second = await describeExpr('0 30 1 * * * *', '2025-10-26T00:31:00Z') // 01:31 BST, already ran
+            iso(second.nextDate).should.eql('2025-10-27T01:30:00.000Z') // NOT 01:30 GMT (second pass) - next day
+        })
+
+        // UK spring forward: Sun 30 Mar 2025, 01:00 GMT -> 02:00 BST (01:00-01:59 local never occurs)
+        it('wildcard schedule should keep its cadence through the missing hour (clocks go forward)', async function () {
+            const describeExpr = await loadDescriber()
+            const result = await describeExpr('0,15,30,45 * * * * * *', '2025-03-30T00:59:50Z') // 00:59:50 GMT
+            iso(result.nextDate).should.eql('2025-03-30T01:00:00.000Z') // = 02:00:00 BST, 10 real seconds later
+        })
+        it('fixed-time schedule in the missing hour should run as soon as possible (clocks go forward)', async function () {
+            const describeExpr = await loadDescriber()
+            const missed = await describeExpr('0 30 1 * * * *', '2025-03-30T00:29:00Z') // 00:29 GMT - 01:30 local will not occur
+            iso(missed.nextDate).should.eql('2025-03-30T01:00:00.000Z') // runs at the transition (02:00 BST)
+            const after = await describeExpr('0 30 1 * * * *', '2025-03-30T01:01:00Z') // just after the transition
+            iso(after.nextDate).should.eql('2025-03-31T00:30:00.000Z') // 01:30 BST the next day
+        })
+
+        // live scheduler (task creation) path - mock timers travel through the transition
+        it('live wildcard schedule should fire during the repeated hour (clocks go back)', { timeout: 10000 }, async function (t) {
+            if (!hasMockDate) {
+                t.skip('Node 20.11+ required for fake timers (Date) to work through DST transition')
+                return
+            }
+            t.mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'], now: new Date('2025-10-26T00:59:50Z').getTime() }) // 01:59:50 BST
+            const drain = () => new Promise(resolve => setImmediate(resolve))
+            try {
+                const flow = [
+                    { id: 'dst3', type: 'cronplus', name: 'dst-live', outputField: 'payload', timeZone: 'Europe/London', persistDynamic: false, commandResponseMsgOutput: 'output1', outputs: 1, options: [{ name: 'every15', topic: 'every15', payloadType: 'default', payload: '', expressionType: 'cron', expression: '0,15,30,45 * * * * * *', location: '', offset: '0' }], wires: [['dst4']] },
+                    { id: 'dst4', type: 'helper' }
+                ]
+                await helper.load(cronplusNode, flow)
+                const dst4 = helper.getNode('dst4')
+                const fires = []
+                dst4.on('input', msg => fires.push(iso(msg.payload.triggerTimestamp)))
+                // advance 35s of fake time through the transition, in small steps so
+                // each fire sees the clock at its own moment
+                for (let i = 0; i < 700; i++) { t.mock.timers.tick(50); await drain() }
+                fires.should.containEql('2025-10-26T01:00:00.000Z') // 01:00:00 GMT - first slot of the repeated hour
+                fires.should.containEql('2025-10-26T01:00:15.000Z')
+            } finally {
+                t.mock.timers.reset()
+            }
+        })
+    })
+
     const getObjectProperty = function (object, path, defaultValue) {
         return path
             // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
Schedules in a DST-observing time zone previously went silent for the entire repeated hour when clocks went back - cronosjs defaults to skipRepeatedHour and cron-plus never set it, so even interval-style jobs (e.g. "every 15 seconds") stopped for an hour.

Follow the Debian cron convention instead:

- A schedule whose minute or hour field starts with `*` is a "wildcard job" (new isWildcardCronJob() classifier). Wildcard jobs keep their real-time interval across a transition, so they also run during the repeated hour when clocks go back.
- A schedule with a fixed hour and minute is a "fixed-time job". It runs only once in a repeated hour, and (via the existing missingHour "insert" behaviour) runs as soon as possible after the transition when clocks going forward skip its scheduled time.

Also fix the describe command to honour its `time` parameter when computing nextDate (previously only nextDates used it), which the new tests rely on to probe transitions at fixed points in time.

Tests cover both transitions for both job classes against the real Europe/London 2025 DST dates, plus a live scheduler test that travels through the fall-back transition with mock timers (skipped below Node 20.11, where MockTimers lacks Date support). 

README documents the rules.

Ref: https://blog.healthchecks.io/2021/10/how-debian-cron-handles-dst-transitions/

closes #108