### PR TITLE
fix: accept the built-in 'memory' context store for Save State

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ Run the following command in the root directory of your Node-RED install.
 
   Or simply copy the folder `node-red-contrib-cron-plus` into a folder named `nodes` inside your node-red folder then `cd` into `nodes/node-red-contrib-cron-plus` and execute `npm install`
 
+Troubleshooting
+---------------
+
+### "Invalid store name specified 'xxx' - state will not be persisted for this node"
+
+The node's **Save State** setting names a node context store that the node-red runtime does not recognise. Context stores are defined in the `contextStorage` section of your node-red settings file (typically `~/.node-red/settings.js`) and the store selected in the node may have been removed or renamed there.
+
+To fix, either select a different **Save State** option in the node's settings, or define the store in your settings file and restart node-red, e.g.:
+
+```javascript
+contextStorage: {
+    default: {
+        module: "localfilesystem"
+    },
+},
+```
+
+> [!NOTE]
+> on a default node-red installation (no `contextStorage` configured), the only context store is the built-in `memory` store. State saved there survives re-deploys but **not** node-red restarts - choose the **File** option (or configure a `localfilesystem` context store) if state must survive a restart.
+
+Context storage is pluggable: besides the built-in `memory` and `localfilesystem` modules, installable plugins provide stores backed by other technologies (e.g. [Redis](https://github.com/node-red/node-red-context-redis), SQLite, PostgreSQL, MySQL/MariaDB), and some platforms (e.g. FlowFuse) provide a persistent context store out of the box. Any store configured in `contextStorage` (or provided by your platform) can be selected in the node's **Save State** setting. See the [node-red context documentation](https://nodered.org/docs/user-guide/context) for details.
+
 Acknowledgements
 ---------------
 * Inspired by [node-red-contrib-cron](https://github.com/chameleonbr/node-red-contrib-cron)

--- a/cronplus.html
+++ b/cronplus.html
@@ -2624,13 +2624,21 @@ function onSchedulesExpandCompress () {
                 <li>Fan out: Separate outputs for static, dynamic and command messages</li>
             </ul>
         </div>
-        <h4>Persist dynamic schedules</h4>
+        <h4>Save State</h4>
         <div style="padding-left: 15px">
-            Enabling this option causes dynamic schedules to be saved to file and re-loaded when the cron-plus node is loaded or re-deployed. <br>
+            Determines where (and if) the node saves its state (dynamic schedules and the
+            paused/started/trigger-count state of all schedules) so it can be restored when the
+            node is redeployed or node-red restarts.
+            <ul>
+                <li><b>None</b>: state is not persisted. Dynamic schedules and schedule state are lost on re-deploy or restart</li>
+                <li><b>File</b>: state is saved to a file in a directory called <code>cronplusdata</code> under your node-red folder. Survives re-deploys and restarts</li>
+                <li><b>Node Context: <i>store</i></b>: state is saved in the named node context store. The available stores come from the <code>contextStorage</code> section of your node-red settings file. Context storage is pluggable - besides the built-in <code>memory</code> and <code>localfilesystem</code> modules, installable plugins provide stores backed by e.g. Redis or a database, and some platforms (e.g. FlowFuse) provide a persistent context store out of the box - any configured store appears here</li>
+            </ul>
             NOTES...
             <ul>
-                <li>Any time an update to any dynamic schedule occurs, all dynamic schedules are saved to file</li>
-                <li>The schedules are saved in a directory called <code>cronplusdata</code> under your node-red folder</li>
+                <li>Any time a schedule changes, the state of all schedules is saved to the chosen store</li>
+                <li>On a default node-red installation (no <code>contextStorage</code> configured in the settings file) the only context store is the built-in <code>memory</code> store. State saved there survives re-deploys but <b>not</b> node-red restarts - choose <b>File</b> or configure a persistent (e.g. <code>localfilesystem</code>) context store if state must survive a restart</li>
+                <li>If the selected store is later removed or renamed in the settings file, the node will warn <code>Invalid store name specified ...</code> at start up and state will not be persisted until the setting is corrected</li>
             </ul>
         </div>
         <h4>Schedules</h4>

--- a/cronplus.js
+++ b/cronplus.js
@@ -908,9 +908,12 @@ module.exports = function (RED) {
             node.storeName = ''
         }
 
+        // context store availability is tracked per node so that one node with a
+        // bad store name cannot disable context persistence for every cronplus node
+        node.contextAvailable = contextAvailable
         if (node.storeName && node.storeName !== 'file' && STORE_NAMES.indexOf(node.storeName) < 0) {
-            node.warn(`Invalid store name specified '${node.storeName}' - state will not be persisted for this node`)
-            contextAvailable = false
+            node.warn(`Invalid store name specified '${node.storeName}' - state will not be persisted for this node. Select a different "Save State" option in the node settings, or add the store to the 'contextStorage' section of the node-red settings file`)
+            node.contextAvailable = false
         }
 
         if (config.commandResponseMsgOutput === 'output2') {
@@ -1746,7 +1749,7 @@ module.exports = function (RED) {
                 } else {
                     const contextKey = 'state'
                     const storeName = node.storeName || 'default'
-                    if (!contextAvailable || STORE_NAMES.indexOf(storeName) === -1) {
+                    if (!node.contextAvailable || STORE_NAMES.indexOf(storeName) === -1) {
                         return
                     }
                     await contextSet(node.context(), contextKey, state, storeName)
@@ -1837,7 +1840,7 @@ module.exports = function (RED) {
                     // use context
                     const storeName = node.storeName || 'default'
                     const contextKey = 'state'
-                    if (!contextAvailable || !STORE_NAMES.indexOf(storeName)) {
+                    if (!node.contextAvailable || STORE_NAMES.indexOf(storeName) === -1) {
                         return
                     }
                     const state = await contextGet(node.context(), contextKey, storeName)
@@ -1983,11 +1986,11 @@ module.exports = function (RED) {
 
     function getStoreNames () {
         const stores = ['', 'file']
-        if (!RED.settings.contextStorage) {
-            return stores
-        }
-        if (typeof RED.settings.contextStorage !== 'object') {
-            return stores
+        if (!RED.settings.contextStorage || typeof RED.settings.contextStorage !== 'object' || Object.keys(RED.settings.contextStorage).length === 0) {
+            // when contextStorage is not configured in the node-red settings file, the
+            // runtime still provides a single built-in in-memory store named 'memory'
+            // (and the editor offers it), so accept it here too (issue #104)
+            return [...stores, 'memory']
         }
         return [...stores, ...Object.keys(RED.settings.contextStorage)]
     }

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -130,6 +130,40 @@ describe('cron-plus Node', function () {
         })
     })
 
+    describe('save state store validation', function () {
+        // issue #104: the editor offers the built-in 'memory' context store on a
+        // default node-red install (no contextStorage configured in settings), but
+        // the runtime rejected it. It must be accepted, and a genuinely unknown
+        // store must produce an actionable warning that does not affect the
+        // persistence of other cronplus nodes.
+        const makeNode = (id, storeName) => ({
+            id, type: 'cronplus', name: 'store test ' + id, outputField: 'payload', timeZone: '', storeName, commandResponseMsgOutput: 'output1', outputs: 1, options: [{ name: 'schedule1', topic: 'schedule1', payloadType: 'default', payload: '', expressionType: 'cron', expression: '0 0 * * * * 2000', location: '', offset: '0' }], wires: [[]]
+        })
+        // the test helper stubs warn at the prototype, so the spy is shared by all
+        // nodes - filter calls by thisValue to get the calls made by *this* node
+        const invalidStoreWarnings = (n) => n.warn.getCalls().filter(c => c.thisValue === n && typeof c.args[0] === 'string' && c.args[0].includes('Invalid store name'))
+
+        it("should accept the built-in 'memory' store, 'file' and none without warning", async function () {
+            const flow = [makeNode('s1', 'memory'), makeNode('s2', 'file'), makeNode('s3', '')]
+            await helper.load(cronplusNode, flow)
+            invalidStoreWarnings(helper.getNode('s1')).should.have.length(0)
+            invalidStoreWarnings(helper.getNode('s2')).should.have.length(0)
+            invalidStoreWarnings(helper.getNode('s3')).should.have.length(0)
+        })
+        it('should warn with guidance for an unknown store, without affecting other nodes', async function () {
+            const flow = [makeNode('s1', 'bogus'), makeNode('s2', 'memory')]
+            await helper.load(cronplusNode, flow)
+            const bad = helper.getNode('s1')
+            const good = helper.getNode('s2')
+            const warnings = invalidStoreWarnings(bad)
+            warnings.should.have.length(1)
+            warnings[0].args[0].should.match(/Invalid store name specified 'bogus'/)
+            warnings[0].args[0].should.match(/contextStorage/) // actionable guidance
+            bad.should.have.property('contextAvailable', false) // per node, not module wide
+            invalidStoreWarnings(good).should.have.length(0)
+        })
+    })
+
     describe('DST transition handling (Debian cron rules)', function () {
         // Jobs whose minute or hour field starts with `*` ("wildcard jobs") keep
         // their real-time interval across a DST change, so they also run during


### PR DESCRIPTION
On a default node-red install (no contextStorage configured in the settings file) the editor offers the built-in 'memory' context store in the Save State dropdown, but the runtime validated the store name against settings.contextStorage - which is undefined - and rejected it with "Invalid store name specified 'memory'". Accept 'memory' when no contextStorage is configured, matching the runtime's actual stores.

Also:
- make the invalid store warning actionable (how to fix it)
- track context store availability per node - previously one node with a bad store name disabled context persistence for every cronplus node
- fix an inverted index check that stopped the state restore path from ever rejecting invalid store names
- replace the outdated "Persist dynamic schedules" built-in help with a "Save State" section (including the memory-store restart caveat) and add a README troubleshooting entry for the exact error text

closes #104