### PR TITLE
Expose custom sun angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ FEATURES
 * Multiple schedules can be entered by the node editor UI or dynamically at runtime
 * Send a default payload or any of the following: timestamp, string, number, boolean, flow variable, global variable, JSON, JSONata, Buffer or Env variable as the output.
 * Example CRON expressions provided in the dropdown to get you started
+* Solar event schedules aren't limited to the usual presets (sunrise, sunset, dusk, dawn, golden hour etc.) - you can also fire on any custom sun angle (e.g. "when the sun is 4° below the horizon, rising") via the "custom angle" checkboxes, or by setting `solarEvents` to `angle:<degrees>:rise` / `angle:<degrees>:set` directly
 * Map popup to help you enter coordinates for solar events
   * Location coordinates can be per schedule, per cron node or set by an environment variable (as of V2.0.0)
   * NOTE: Map is 100% CDN dynamic and requires and internet connection. If there is no internet, the popup will provide information to help you get location coordinates from another source

--- a/cronplus.html
+++ b/cronplus.html
@@ -1858,10 +1858,13 @@ copies or substantial portions of the Software.
                     const isAngleMode = scheduleTypeField.val() === 'solar' && solarEventsField.typedInput('type') === 'selected' &&
                         (events.includes(CUSTOM_ANGLE_RISE_SENTINEL) || events.includes(CUSTOM_ANGLE_SET_SENTINEL))
                     if (isAngleMode) {
-                        offsetField.attr({ min: -90, max: 90, placeholder: 'custom angle °' })
+                        // 'any' permits fractional degrees (e.g. 1.5) - without it the browser's
+                        // native number-input validation defaults to step=1 and flags any decimal
+                        // value as invalid (red outline), even though the field itself accepts it
+                        offsetField.attr({ min: -90, max: 90, step: 'any', placeholder: 'custom angle °' })
                         offsetField.prop('title', "Custom angle in degrees, above (+) or below (-) the horizon - used by the 'custom angle (rising)'/'custom angle (setting)' checkboxes above")
                     } else {
-                        offsetField.attr({ min: -1439, max: 1439, placeholder: 'offset' })
+                        offsetField.attr({ min: -1439, max: 1439, step: 1, placeholder: 'offset' })
                         offsetField.prop('title', 'Minutes Offset +/- 1439')
                     }
                 }

--- a/cronplus.html
+++ b/cronplus.html
@@ -432,6 +432,63 @@ copies or substantial portions of the Software.
         }
     }
 
+    // Matches a custom solar-angle event token e.g. "angle:-4:rise" or "angle:6.5:set"
+    // (kept in sync with SOLAR_ANGLE_EVENT_REGEX in cronplus.js)
+    const SOLAR_ANGLE_EVENT_REGEX = /^angle:(-?\d+(?:\.\d+)?):(rise|set)$/i
+
+    // Sentinel values shown as two extra checkboxes in the "Selected Solar Events" list, meaning
+    // "use the angle entered in the offset box below" (which doubles as the custom-angle degrees
+    // box while either of these is ticked - see updateOffsetFieldMode() in generateOption()).
+    // These are swapped for real angle:<degrees>:rise|set tokens when persisting (see
+    // getSolarEventsForOption()) and swapped back to sentinels (with the box pre-filled) when a
+    // schedule is reopened for editing - this keeps the custom-angle feature living inside the
+    // existing preset-events checkbox widget instead of a separate control.
+    const CUSTOM_ANGLE_RISE_SENTINEL = 'customAngleRise'
+    const CUSTOM_ANGLE_SET_SENTINEL = 'customAngleSet'
+
+    /**
+     * Given a schedule row's <li> element, combine the preset solar-event checkbox selector's
+     * value with the offset/angle box into the final solarType/solarEvents/offset that should be
+     * persisted. The offset box doubles as the custom-angle degrees box: if the schedule is a
+     * *solar* schedule and either of the "custom angle (rising)"/"custom angle (setting)"
+     * checkboxes is ticked, the sentinel is swapped out for a real angle:<degrees>:rise|set token
+     * using the box's value (as degrees, not minutes), and the persisted offset is forced to 0
+     * since the box is being used for the angle instead in that case. Lunar schedules (which
+     * share the same offset field) are never affected by this, even if a solar row's stale
+     * selection still contains a custom-angle sentinel.
+     * @param {JQuery} $optionLi the <li> element for this schedule row
+     * @returns {{solarType: string, solarEvents: string, offset: (string|number)}}
+     */
+    function getSolarEventsForOption ($optionLi) {
+        const $solarEventsField = $optionLi.find('.node-input-option-solarEvents')
+        const $offsetField = $optionLi.find('.node-input-option-offset')
+        const expressionType = $optionLi.find('.node-input-option-expressionType').val()
+        const solarType = $solarEventsField.typedInput('type') || 'all'
+        const rawOffset = $offsetField.val()
+        if (expressionType !== 'solar' || solarType !== 'selected') {
+            $offsetField.removeClass('input-error')
+            return { solarType, solarEvents: $solarEventsField.typedInput('value') || '', offset: rawOffset }
+        }
+        let events = String($solarEventsField.typedInput('value') || '').split(',').map(function (s) { return s.trim() }).filter(Boolean)
+        const wantsRise = events.includes(CUSTOM_ANGLE_RISE_SENTINEL)
+        const wantsSet = events.includes(CUSTOM_ANGLE_SET_SENTINEL)
+        let offset = rawOffset
+        if (wantsRise || wantsSet) {
+            const angleVal = parseFloat(rawOffset)
+            const angleValid = rawOffset !== '' && !isNaN(angleVal) && angleVal >= -90 && angleVal <= 90
+            $offsetField.toggleClass('input-error', !angleValid)
+            events = events.filter(function (e) { return e !== CUSTOM_ANGLE_RISE_SENTINEL && e !== CUSTOM_ANGLE_SET_SENTINEL })
+            if (angleValid) {
+                if (wantsRise) events.push(`angle:${angleVal}:rise`)
+                if (wantsSet) events.push(`angle:${angleVal}:set`)
+            }
+            offset = 0 // the box holds the angle in this mode, not a minutes offset
+        } else {
+            $offsetField.removeClass('input-error')
+        }
+        return { solarType, solarEvents: events.join(','), offset }
+    }
+
     function showSidebarHelpPanel () {
         if (RED.sidebar.help) {
             RED.sidebar.help.show()//  >= V1.1.0
@@ -1306,7 +1363,9 @@ copies or substantial portions of the Software.
                 makeSolarChoice('nauticalDusk', 'nautical dusk', 'nautical twilight ends, astronomical twilight starts (-12°)'),
                 // makeSolarChoice("astronomicalDusk", "astronomical dusk", "astronomical twilight ends, night starts (-18°)"),
                 makeSolarChoice('nightStart', 'astronomical dusk / night start', 'astronomical twilight ends, night starts (-18°)'), // needed? same as astronomicalDusk
-                makeSolarChoice('nadir', 'solar midnight', 'when the sun is closest to nadir and the night is equidistant from dusk and dawn')
+                makeSolarChoice('nadir', 'solar midnight', 'when the sun is closest to nadir and the night is equidistant from dusk and dawn'),
+                makeSolarChoice(CUSTOM_ANGLE_RISE_SENTINEL, 'custom angle (rising)', 'fires as the sun rises through the angle entered in the offset box (used as degrees, not minutes, while this is ticked)'),
+                makeSolarChoice(CUSTOM_ANGLE_SET_SENTINEL, 'custom angle (setting)', 'fires as the sun sets through the angle entered in the offset box (used as degrees, not minutes, while this is ticked)')
             ]
             const lunarChoices = [
                 makeSolarChoice('rise', 'moon rise', 'the moon rises above the horizon'),
@@ -1455,10 +1514,18 @@ copies or substantial portions of the Software.
                             content: function (callback) {
                                 if (RED._cron_plus_debug) console.debug('initTooltip-->content')
 
-                                const solarType = $solarEvents.typedInput('type')
-                                const solarEvents = $solarEvents.typedInput('value')
                                 const expressionType = $expressionType.val()
-                                const offset = $offset.val()
+                                let solarType, solarEvents, offset
+                                if (expressionType === 'solar') {
+                                    const solarMerged = getSolarEventsForOption($this.closest('li'))
+                                    solarType = solarMerged.solarType
+                                    solarEvents = solarMerged.solarEvents
+                                    offset = solarMerged.offset
+                                } else {
+                                    solarType = $solarEvents.typedInput('type')
+                                    solarEvents = $solarEvents.typedInput('value')
+                                    offset = $offset.val()
+                                }
                                 const timeZone = $timeZone.val()
                                 let titleHtml
                                 const e = { expressionType }
@@ -1691,9 +1758,19 @@ copies or substantial portions of the Software.
                 } catch (_error) { }
                 expressionField.combobox('value', option.expression || '')
 
-                // generate the solar events field
+                // generate the solar events field - any existing angle:<deg>:rise|set tokens are
+                // converted to the CUSTOM_ANGLE_*_SENTINEL checkbox values here, with the degrees
+                // extracted for pre-filling the offset box (which doubles as the angle box - see below)
                 const solarEventsDiv = $('<div/>', { style: solarEventsStyle }).appendTo(cell2Solar)
-                const solarEventsField = $('<input/>', { class: 'node-input-option-solarEvents', type: 'text', style: 'width: 100%', placeholder: 'select solar events', value: option.solarEvents || '' }).appendTo(solarEventsDiv)
+                const solarEventsRaw = (option.solarEvents || '').split(',').map(function (s) { return s.trim() }).filter(Boolean)
+                let initialCustomAngleValue = null
+                const initialSolarEvents = solarEventsRaw.map(function (token) {
+                    const m = SOLAR_ANGLE_EVENT_REGEX.exec(token)
+                    if (!m) return token
+                    initialCustomAngleValue = m[1]
+                    return m[2].toLowerCase() === 'rise' ? CUSTOM_ANGLE_RISE_SENTINEL : CUSTOM_ANGLE_SET_SENTINEL
+                }).join(',')
+                const solarEventsField = $('<input/>', { class: 'node-input-option-solarEvents', type: 'text', style: 'width: 100%', placeholder: 'select solar events', value: initialSolarEvents }).appendTo(solarEventsDiv)
                 solarEventsField.typedInput({
                     default: 'all',
                     types: [
@@ -1718,7 +1795,7 @@ copies or substantial portions of the Software.
                     ]
                 })
                 solarEventsField.typedInput('type', option.solarType || 'all')
-                solarEventsField.typedInput('value', option.solarEvents || '')// added as setting value on invocation doesnt seem to set the "2 selected" text of the widget!
+                solarEventsField.typedInput('value', initialSolarEvents)// added as setting value on invocation doesnt seem to set the "2 selected" text of the widget!
 
                 // generate the lunar events field (occupies the same slot as solar events - visibility is switched by schedule type)
                 const lunarEventsDiv = $('<div/>', { style: solarEventsStyle }).appendTo(cell2Solar)
@@ -1768,9 +1845,28 @@ copies or substantial portions of the Software.
                 })
                 locationField.typedInput('value', option.location || '')
 
-                // offset fields
-                const offsetField = $('<input/>', { class: 'node-input-option-offset', type: 'number', min: -1439, max: 1439, style: solarOffsetStyle, value: option.offset || 0, placeholder: 'offset' }).appendTo(cell2Solar)
-                offsetField.prop('title', 'Minutes Offset +/- 1439')
+                // offset field - shared between solar & lunar schedules (minutes offset applied to
+                // whichever event time is calculated). It also doubles as the custom-angle degrees
+                // box: while the schedule is a *solar* schedule AND either "custom angle (rising)"/
+                // "custom angle (setting)" is ticked above, this field's value is used as the angle
+                // (in degrees) instead of a minutes offset (see getSolarEventsForOption() and
+                // updateOffsetFieldMode() below). Lunar schedules always use it as a plain offset.
+                const offsetField = $('<input/>', { class: 'node-input-option-offset', type: 'number', style: solarOffsetStyle, value: (initialCustomAngleValue != null ? initialCustomAngleValue : (option.offset || 0)) }).appendTo(cell2Solar)
+
+                function updateOffsetFieldMode () {
+                    const events = String(solarEventsField.typedInput('value') || '').split(',').map(function (s) { return s.trim() })
+                    const isAngleMode = scheduleTypeField.val() === 'solar' && solarEventsField.typedInput('type') === 'selected' &&
+                        (events.includes(CUSTOM_ANGLE_RISE_SENTINEL) || events.includes(CUSTOM_ANGLE_SET_SENTINEL))
+                    if (isAngleMode) {
+                        offsetField.attr({ min: -90, max: 90, placeholder: 'custom angle °' })
+                        offsetField.prop('title', "Custom angle in degrees, above (+) or below (-) the horizon - used by the 'custom angle (rising)'/'custom angle (setting)' checkboxes above")
+                    } else {
+                        offsetField.attr({ min: -1439, max: 1439, placeholder: 'offset' })
+                        offsetField.prop('title', 'Minutes Offset +/- 1439')
+                    }
+                }
+                updateOffsetFieldMode()
+                solarEventsField.on('change', updateOffsetFieldMode)
 
                 // init tooltips
                 initTooltip(offsetField, 'solar', { my: 'middle top', at: 'middle bottom+5', of: cell2Solar, collision: 'flipfit' })
@@ -1827,6 +1923,7 @@ copies or substantial portions of the Software.
                             expressionField.combobox('showMenu')
                             break
                     }
+                    updateOffsetFieldMode()
                 })
                 scheduleTypeField.triggerHandler('change')
                 $('#node-input-option-container').append(container)
@@ -1917,6 +2014,7 @@ copies or substantial portions of the Software.
             // eslint-disable-next-line no-unused-vars
             options.each(function (i) {
                 const option = $(this)
+                const solar = getSolarEventsForOption(option)
                 const o = {
                     name: option.find('.node-input-option-name').val(),
                     topic: option.find('.node-input-option-topic').val(),
@@ -1925,9 +2023,9 @@ copies or substantial portions of the Software.
                     expressionType: option.find('.node-input-option-expressionType').val(),
                     expression: option.find('.node-input-option-expression').val(),
                     location: option.find('.node-input-option-location').typedInput('value'),
-                    offset: option.find('.node-input-option-offset').val(),
-                    solarType: option.find('.node-input-option-solarEvents').typedInput('type') || 'all',
-                    solarEvents: option.find('.node-input-option-solarEvents').typedInput('value'),
+                    offset: solar.offset,
+                    solarType: solar.solarType,
+                    solarEvents: solar.solarEvents,
                     lunarType: option.find('.node-input-option-lunarEvents').typedInput('type') || 'all',
                     lunarEvents: option.find('.node-input-option-lunarEvents').typedInput('value')
                 }
@@ -2514,6 +2612,20 @@ function onSchedulesExpandCompress () {
                 <tr><td>nightStart</td><td>astronomical dusk / night start</td><td>astronomical twilight ends, night starts (-18°)</td></tr>
                 <tr><td>nadir</td><td>solar midnight</td><td>when the sun is closest to nadir and the night is equidistant from dusk and dawn</td></tr>
             </table>
+            <p>
+                <b>Custom sun angle</b> - if none of the presets above are the angle you need, tick
+                <i>custom angle (rising)</i> and/or <i>custom angle (setting)</i> in the list above,
+                then enter the angle (in degrees, -90 to 90) in the <i>offset</i> box (see
+                <a href="#cron-plus-solar-offset-info">Schedules - Offset</a> below - while either
+                of these is ticked, that box is used as the angle in degrees instead of a minutes
+                offset). Ticking both fires on the same angle both as the sun rises through it
+                (morning) and as it sets through it (evening). Internally this is stored as an extra
+                solar event of the form <code>angle:&lt;degrees&gt;:rise</code> or
+                <code>angle:&lt;degrees&gt;:set</code> (e.g. <code>angle:-4:rise</code>), so it can
+                also be set directly via <code>solarEvents</code> when adding/updating a schedule
+                dynamically via msg (in which case a normal minutes <code>offset</code> can still be
+                combined with it).
+            </p>
         </div>
         <h4 id="cron-plus-lunar-events-info">Schedules - Lunar Events</h4>
         <div style="padding-left: 15px">
@@ -2539,10 +2651,14 @@ function onSchedulesExpandCompress () {
                 <li>GPS E.g: <code>N54°59'57.3, W1°25'1.308"</code>, <code>54°59'57.3"N, 1°25'1.308"W</code>, <code>54d 59' 57" N 1d 25' 1" W</code> or <code>54:59:57.3N 1:25:1.308W</code></li>
             </ul>
         </div>
-        <h4>Schedules - Offset</h4>
+        <h4 id="cron-plus-solar-offset-info">Schedules - Offset</h4>
         <div style="padding-left: 15px">
-            <i>NOTE: Only displayed when the type is set to <b>solar events</b></i><br>
-            The offset field can be used to add a positive or negative offset in minutes to the sunrise or sunset time.
+            <i>NOTE: Only displayed when the type is set to <b>solar events</b> or <b>lunar events</b></i><br>
+            The offset field can be used to add a positive or negative offset in minutes to the calculated event time.<br>
+            <i>NOTE: for solar schedules, while either <b>custom angle (rising)</b> or <b>custom angle
+            (setting)</b> is ticked in the solar events list above, this field is repurposed as the
+            custom angle in degrees (-90 to 90) instead of a minutes offset - see <b>Custom sun angle</b>
+            above.</i>
         </div>
 
     </dl>
@@ -2642,7 +2758,7 @@ function onSchedulesExpandCompress () {
                         <li>topic: (string|required) This will be used as the topic when the schedule triggers</li>
                         <li>expressionType: (string|required) specify the schedule type. Set to "solar" for solar events</li>
                         <li>solarType: (string|required) specify the events to fire.  Accepted values are "all" or "selected"</li>
-                        <li>solarEvents: (string|optional) specify the events to fire. Only required when solarType == "selected". Accepted values are listed under <b>Schedules - Solar Events</b> <a href="#cron-plus-solar-events-info">see above</a> </li>
+                        <li>solarEvents: (string|optional) specify the events to fire. Only required when solarType == "selected". Accepted values are listed under <b>Schedules - Solar Events</b> <a href="#cron-plus-solar-events-info">see above</a>, plus custom sun angle events in the form <code>angle:&lt;degrees&gt;:rise</code> or <code>angle:&lt;degrees&gt;:set</code> (e.g. <code>angle:-4:rise</code>) </li>
                         <li>location: (string|required) longitude latitude, DNS, DMM or GPS coordinates for sunrise or sunset</li>
                         <li>offset: (number|optional) number of minutes to offset a sunrise or sunset</li>
                         <li>payloadType: (string|optional) The payload type (e.g. 'default', 'flow', 'global', 'str', 'num', 'bool', 'json', 'bin', 'date' or 'env')</li>

--- a/cronplus.js
+++ b/cronplus.js
@@ -292,6 +292,19 @@ function validateOpt (opt, permitDefaults = true) {
 }
 
 /**
+ * Human-friendly label for a "next event" identifier, for user-facing text only (node status,
+ * the dynamic-schedules viewer, tooltips, "pretty" descriptions). Named presets (solar or lunar)
+ * and non-solar events are returned unchanged; custom solar-angle tokens are expanded to a
+ * readable phrase. Callers that need the exact machine identifier (e.g. msg.cronplus.status.solarEvent,
+ * or the `nextEvent` field itself) should keep using the raw value - this helper is for display text only.
+ * @param {string} eventId the raw event identifier, e.g. "sunrise" or "angle:-4:rise"
+ * @returns {string}
+ */
+function getEventDisplayLabel (eventId) {
+    return isCustomSolarAngleEvent(eventId) ? describeCustomSolarAngleEvent(eventId) : eventId
+}
+
+/**
  * Tests if a string or array of date like items are a date or date sequence
  * @param {String|Array} data An array of date like entries or a CSV string of dates
  */
@@ -441,7 +454,7 @@ function _describeExpression (expression, expressionType, timeZone, offset, sola
         if (task && task._sequence && count) {
             result.nextDate = dsFutureDates[0]
             const ms = result.nextDate.valueOf() - now.valueOf()
-            result.prettyNext = (result.nextEvent ? result.nextEvent + ' ' : '') + `in ${prettyMs(ms, { secondsDecimalDigits: 0, verbose: true })}`
+            result.prettyNext = (result.nextEvent ? getEventDisplayLabel(result.nextEvent) + ' ' : '') + `in ${prettyMs(ms, { secondsDecimalDigits: 0, verbose: true })}`
             if (expressionType === 'solar') {
                 if (solarType === 'all') {
                     result.description = 'All Solar Events'
@@ -2246,7 +2259,7 @@ module.exports = function (RED) {
                 const indicator = node.nextIndicator || 'dot'
                 if (node.nextDate) {
                     const d = formatShortDateTimeWithTZ(node.nextDate, node.timeZone) || 'Never'
-                    node.status({ fill: 'blue', shape: indicator, text: (node.nextEvent || 'Next') + ': ' + d })
+                    node.status({ fill: 'blue', shape: indicator, text: (node.nextEvent ? getEventDisplayLabel(node.nextEvent) : 'Next') + ': ' + d })
                 } else if (node.tasks && node.tasks.length) {
                     node.status({ fill: 'grey', shape: indicator, text: 'All stopped' })
                 } else {
@@ -2471,7 +2484,7 @@ module.exports = function (RED) {
                         // next: next,
                         next: h.nextEventTimeOffset,
                         // nextEventDesc: nextEventDesc,
-                        nextEventDesc: h.nextEvent,
+                        nextEventDesc: h.nextEvent ? getEventDisplayLabel(h.nextEvent) : h.nextEvent,
                         // prettyNext: prettyNext,
                         prettyNext: h.prettyNext,
                         // nextDates: nextDates

--- a/cronplus.js
+++ b/cronplus.js
@@ -51,6 +51,73 @@ const PERMITTED_LUNAR_EVENTS = [
     'set'
 ]
 
+// Matches a custom solar-angle event token e.g. "angle:-4:rise" or "angle:6.5:set"
+// angle is degrees above (positive) or below (negative) the horizon; direction is
+// whether the sun is rising through that angle (morning) or setting through it (evening)
+const SOLAR_ANGLE_EVENT_REGEX = /^angle:(-?\d+(?:\.\d+)?):(rise|set)$/i
+
+/**
+ * Parse a custom solar-angle event token into its angle (degrees) & direction
+ * @param {string} value e.g. "angle:-4:rise"
+ * @returns {{angle: number, direction: ('rise'|'set')}|null} null if invalid, malformed, or out of range
+ */
+function parseCustomSolarAngleEvent (value) {
+    const match = SOLAR_ANGLE_EVENT_REGEX.exec(String(value || '').trim())
+    if (!match) return null
+    const angle = parseFloat(match[1])
+    if (isNaN(angle) || angle < -90 || angle > 90) return null
+    return { angle, direction: match[2].toLowerCase() }
+}
+
+/**
+ * Determine whether a string is a valid (well formed AND in-range) custom solar-angle event
+ * token (e.g. "angle:-4:rise"). This is the single source of truth for validity - it delegates
+ * to parseCustomSolarAngleEvent() so that anything accepted here is guaranteed to parse.
+ * @param {string} value the candidate solar event token
+ * @returns {boolean}
+ */
+function isCustomSolarAngleEvent (value) {
+    return typeof value === 'string' && parseCustomSolarAngleEvent(value) !== null
+}
+
+/**
+ * Produce a human friendly description of a custom solar-angle event token
+ * @param {string} value e.g. "angle:-4:rise"
+ * @returns {string}
+ */
+function describeCustomSolarAngleEvent (value) {
+    const parsed = parseCustomSolarAngleEvent(value)
+    if (!parsed) return value
+    const { angle, direction } = parsed
+    const verb = direction === 'rise' ? 'rising' : 'setting'
+    const position = angle === 0 ? 'at the horizon' : (angle > 0 ? `${angle}° above the horizon` : `${Math.abs(angle)}° below the horizon`)
+    return `sun ${verb} ${position}`
+}
+
+// Cache of custom angles already registered with SunCalc. SunCalc.addTime() simply pushes
+// a new entry onto its internal (module scoped) `times` array every time it's called with
+// no de-duplication, so registering the same angle repeatedly (e.g. every time a schedule
+// is (re)computed) would leak memory and duplicate work - this cache prevents that.
+const registeredSolarAngles = new Map()
+
+/**
+ * Ensure a custom solar angle is registered with SunCalc, returning the generated rise/set
+ * property names that SunCalc.getTimes() will then populate for that angle.
+ * @param {number} angle Angle in degrees above (positive) or below (negative) the horizon
+ * @returns {{riseName: string, setName: string}}
+ */
+function ensureCustomSolarAngleRegistered (angle) {
+    const key = angle.toFixed(4)
+    let names = registeredSolarAngles.get(key)
+    if (!names) {
+        const safeKey = key.replace('-', 'n').replace('.', 'p')
+        names = { riseName: `customAngle_${safeKey}_rise`, setName: `customAngle_${safeKey}_set` }
+        SunCalc.addTime(angle, names.riseName, names.setName)
+        registeredSolarAngles.set(key, names)
+    }
+    return names
+}
+
 // accepted commands using topic as the command & (in compatible cases, the payload is the schedule name)
 // commands not supported by topic are : add/update & describe
 const controlTopics = [
@@ -191,8 +258,10 @@ function validateOpt (opt, permitDefaults = true) {
             }
             for (let index = 0; index < selectedEvents.length; index++) {
                 const element = selectedEvents[index].trim()
-                if (!permittedEvents.includes(element)) {
-                    throw new Error(`Schedule '${opt.name}' - ${isSolar ? 'solar' : 'lunar'}Events entry '${element}' is invalid`)
+                const isPermitted = permittedEvents.includes(element) || (isSolar && isCustomSolarAngleEvent(element))
+                if (!isPermitted) {
+                    const suffix = isSolar ? " or a custom angle in the form 'angle:<degrees>:rise' or 'angle:<degrees>:set' (degrees between -90 and 90)" : ''
+                    throw new Error(`Schedule '${opt.name}' - ${isSolar ? 'solar' : 'lunar'}Events entry '${element}' is invalid${suffix}`)
                 }
             }
         }
@@ -377,7 +446,11 @@ function _describeExpression (expression, expressionType, timeZone, offset, sola
                 if (solarType === 'all') {
                     result.description = 'All Solar Events'
                 } else {
-                    result.description = "Solar Events: '" + solarEvents.split(',').join(', ') + "'"
+                    const labels = solarEvents.split(',').map((se) => {
+                        se = se.trim()
+                        return isCustomSolarAngleEvent(se) ? describeCustomSolarAngleEvent(se) : se
+                    })
+                    result.description = "Solar Events: '" + labels.join(', ') + "'"
                 }
             } else if (expressionType === 'lunar') {
                 if (lunarType === 'all') {
@@ -633,10 +706,21 @@ function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offs
     }
     for (let index = 0; index < solarEventsArrTemp.length; index++) {
         const se = solarEventsArrTemp[index].trim()
-        if (PERMITTED_SOLAR_EVENTS.includes(se)) {
+        if (PERMITTED_SOLAR_EVENTS.includes(se) || isCustomSolarAngleEvent(se)) {
             solarEventsArr.push(se)
         }
     }
+
+    // custom (user specified angle) events are tracked separately since they are not part of
+    // SunCalc's/PERMITTED_SOLAR_EVENTS' fixed set of named presets - they must be registered with
+    // SunCalc (once) before SunCalc.getTimes() will return a time for them.
+    const customAngleEventDefs = solarEventsArr.filter(isCustomSolarAngleEvent).map((token) => {
+        const parsed = parseCustomSolarAngleEvent(token)
+        const names = ensureCustomSolarAngleRegistered(parsed.angle)
+        return { token, internalName: parsed.direction === 'rise' ? names.riseName : names.setName }
+    })
+    const customAngleEventsPast = [...customAngleEventDefs]
+    const customAngleEventsFuture = [...customAngleEventDefs]
 
     offset = isNumber(offset) ? parseInt(offset) : 0
     elevation = isNumber(elevation) ? parseInt(elevation) : 0// not used for now
@@ -652,7 +736,7 @@ function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offs
     // performance.mark('FirstScanStart');
 
     // first scan backwards to get prior solar events
-    while (loopMonitor < 3 && solarEventsPast.length) {
+    while (loopMonitor < 3 && (solarEventsPast.length || customAngleEventsPast.length)) {
         loopMonitor++
         const timesIteration1 = getSunTimes(scanDate, lat, lng)
         // timesIteration1 = new SolarCalc(scanDate,lat,lng);
@@ -672,6 +756,19 @@ function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offs
                 index--
             }
         }
+        for (let index = 0; index < customAngleEventsPast.length; index++) {
+            const ce = customAngleEventsPast[index]
+            const seTime = timesIteration1[ce.internalName]
+            if (!seTime || !isValidDateObject(seTime)) {
+                continue
+            }
+            const seTimeOffset = new Date(seTime.getTime() + offset * 60000)
+            if (isValidDateObject(seTimeOffset) && seTimeOffset <= startDate) {
+                result.push({ event: ce.token, time: seTime, timeOffset: seTimeOffset })
+                customAngleEventsPast.splice(index, 1)// remove that item
+                index--
+            }
+        }
         scanDate.setDate(scanDate.getDate() - 1)
     }
 
@@ -679,7 +776,7 @@ function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offs
     scanDate.setDate(scanDate.getDate() - 1)// back one day to catch times ahead of current day
     loopMonitor = 0
     // now scan forwards to get future events
-    while (loopMonitor < 183 && solarEventsFuture.length) {
+    while (loopMonitor < 183 && (solarEventsFuture.length || customAngleEventsFuture.length)) {
         loopMonitor++
         const timesIteration2 = getSunTimes(scanDate, lat, lng)
         // timesIteration2 = new SolarCalc(scanDate,lat,lng);
@@ -693,6 +790,19 @@ function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offs
             if (isValidDateObject(seTimeOffset) && seTimeOffset > startDate) {
                 result.push({ event: se, time: seTime, timeOffset: seTimeOffset })
                 solarEventsFuture.splice(index, 1)// remove that item
+                index--
+            }
+        }
+        for (let index = 0; index < customAngleEventsFuture.length; index++) {
+            const ce = customAngleEventsFuture[index]
+            const seTime = timesIteration2[ce.internalName]
+            if (!seTime || !isValidDateObject(seTime)) {
+                continue
+            }
+            const seTimeOffset = new Date(seTime.getTime() + offset * 60000)
+            if (isValidDateObject(seTimeOffset) && seTimeOffset > startDate) {
+                result.push({ event: ce.token, time: seTime, timeOffset: seTimeOffset })
+                customAngleEventsFuture.splice(index, 1)// remove that item
                 index--
             }
         }

--- a/cronplus.js
+++ b/cronplus.js
@@ -1953,6 +1953,16 @@ module.exports = function (RED) {
                 }
                 opt.payloadType = opt.payloadType || 'default'
                 delete opt.type
+                // a dynamically added/updated schedule doesn't know about the node's own
+                // "Default Location" setting (fixed/env, applying to every solar/lunar
+                // schedule on this node) unless we tell it - without this, validateOpt()
+                // would reject a solar/lunar schedule that omits `location` even though
+                // the node-level default would have supplied it (see createTask(), which
+                // does the same via applyOptionDefaults() for static schedules)
+                if ((opt.expressionType === 'solar' || opt.expressionType === 'lunar') &&
+                    (node.defaultLocationType === 'env' || node.defaultLocationType === 'fixed')) {
+                    opt.locationType = node.defaultLocationType
+                }
                 try {
                     validateOpt(opt)
                 } catch (error) {

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -242,6 +242,87 @@ describe('cron-plus Node', function () {
         })
     })
 
+    describe('dynamic schedules and the node-level default location', function () {
+        // bug found while testing custom-angle dynamic schedules: a schedule added via msg is
+        // validated *before* the node's own "Default Location" (fixed/env) setting is applied to
+        // it (that only happened for static schedules, via createTask() -> applyOptionDefaults()).
+        // A dynamic solar/lunar schedule that omits `location` - expecting the node-level default
+        // to supply it, exactly as static schedules already do - was incorrectly rejected with
+        // "location property missing". This is not specific to custom-angle events; it affects any
+        // dynamic solar/lunar schedule when the node has a fixed/env default location configured.
+        const makeNode = (defaultLocationType, defaultLocation) => ([
+            { id: 'helperCmd', type: 'helper' },
+            {
+                id: 'defLocNode',
+                type: 'cronplus',
+                name: 'default-location-test',
+                outputField: 'payload',
+                timeZone: '',
+                defaultLocationType,
+                defaultLocation,
+                persistDynamic: false,
+                commandResponseMsgOutput: 'output1',
+                outputs: 1,
+                options: [],
+                wires: [['helperCmd']]
+            }
+        ])
+
+        it("accepts a dynamic solar schedule with no location when the node's default location is 'fixed'", async function () {
+            await helper.load(cronplusNode, makeNode('fixed', '54.9992500,-1.4170300'))
+            const node = helper.getNode('defLocNode')
+            const helperCmd = helper.getNode('helperCmd')
+
+            node.receive({
+                payload: {
+                    command: 'add',
+                    name: 'testAngle',
+                    topic: 'testAngle',
+                    expressionType: 'solar',
+                    solarType: 'selected',
+                    solarEvents: 'angle:-4:rise',
+                    offset: 0,
+                    payloadType: 'default'
+                    // no `location` - the node-level default must supply it
+                }
+            })
+            await sleep(50)
+
+            const locationWarnings = node.warn.getCalls().filter(c => c.args[0] && String(c.args[0].message || c.args[0]).includes('location property missing'))
+            locationWarnings.should.have.length(0)
+
+            const listPromise = new Promise(resolve => helperCmd.once('input', resolve))
+            node.receive({ payload: { command: 'list', name: 'testAngle' } })
+            const result = await listPromise
+            result.payload.result.should.have.property('config').which.is.an.Object()
+            result.payload.result.config.should.have.property('location', '54.9992500,-1.4170300')
+            result.payload.result.config.should.have.property('solarEvents', 'angle:-4:rise')
+        })
+
+        it("still requires a location on a dynamic schedule when the node's default location is 'per schedule'", async function () {
+            // sanity check the fix doesn't over-relax validation for the normal case
+            await helper.load(cronplusNode, makeNode('default', ''))
+            const node = helper.getNode('defLocNode')
+
+            node.receive({
+                payload: {
+                    command: 'add',
+                    name: 'noLocation',
+                    topic: 'noLocation',
+                    expressionType: 'solar',
+                    solarType: 'all',
+                    offset: 0,
+                    payloadType: 'default'
+                    // no `location`, and no node-level default either - this must still fail
+                }
+            })
+            await sleep(50)
+
+            const locationWarnings = node.warn.getCalls().filter(c => c.args[0] && String(c.args[0].message || c.args[0]).includes('location property missing'))
+            locationWarnings.should.have.length(1)
+        })
+    })
+
     describe('DST transition handling (Debian cron rules)', function () {
         // Jobs whose minute or hour field starts with `*` ("wildcard jobs") keep
         // their real-time interval across a DST change, so they also run during

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -794,6 +794,57 @@ describe('cron-plus Node', function () {
             const result = await resultPromise
             commandChecker(result, test)
         })
+        it('describe a custom solar angle event (angle:-4:rise)', async function (t) {
+            const test = {
+                description: t.name,
+                send: { payload: { command: 'describe', expressionType: 'solar', location: '54.9992500,-1.4170300', solarType: 'selected', solarEvents: 'angle:-4:rise', timeZone: 'Europe/London' } },
+                expected: { command: 'describe', propertyValues: [['payload.result.description', 'string', "Solar Events: 'sun rising 4° below the horizon'"]] }
+            }
+            const resultPromise = new Promise(resolve => {
+                helperNodeCommandResponses.on('input', (msg) => {
+                    resolve(msg)
+                })
+            })
+            testNode.receive(test.send)
+            const result = await resultPromise
+            commandChecker(result, test)
+            result.payload.result.should.have.property('nextEvent', 'angle:-4:rise')
+            result.payload.result.should.have.property('nextEventTimeOffset').which.is.a.Date()
+        })
+        it('describe a custom solar angle event mixed with a preset event', async function (t) {
+            const test = {
+                description: t.name,
+                send: { payload: { command: 'describe', expressionType: 'solar', location: '54.9992500,-1.4170300', solarType: 'selected', solarEvents: 'angle:6:set,sunrise', timeZone: 'Europe/London' } },
+                expected: { command: 'describe', propertyValues: [['payload.result.nextEvent', 'string']] }
+            }
+            const resultPromise = new Promise(resolve => {
+                helperNodeCommandResponses.on('input', (msg) => {
+                    resolve(msg)
+                })
+            })
+            testNode.receive(test.send)
+            const result = await resultPromise
+            commandChecker(result, test)
+            result.payload.result.nextEvent.should.be.oneOf('angle:6:set', 'sunrise')
+        })
+        it('should reject adding a schedule with an out-of-range custom solar angle', async function () {
+            testNode.receive({
+                payload: {
+                    command: 'add',
+                    name: 'dynBadAngle',
+                    topic: 'dynBadAngle',
+                    expressionType: 'solar',
+                    location: '54.9992500,-1.4170300',
+                    solarType: 'selected',
+                    solarEvents: 'angle:120:rise',
+                    payloadType: 'default',
+                    limit: 1
+                }
+            })
+            await sleep(50) // let it unwind
+            const warnCall = testNode.warn.getCalls().find(c => c.args[0] && String(c.args[0].message || c.args[0]).includes("solarEvents entry 'angle:120:rise' is invalid"))
+            should(warnCall).not.be.undefined()
+        })
         it('describe lunar events for a location', async function (t) {
             const test = {
                 description: t.name,

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -164,6 +164,84 @@ describe('cron-plus Node', function () {
         })
     })
 
+    describe('custom solar angle events - dynamic schedule persistence shape', function () {
+        // NOTE: this repo's test harness intentionally forces FSAvailable/contextAvailable to
+        // false under `testMode` (see cronplus.js) so tests never touch real files or context
+        // stores - genuine disk/context round-tripping therefore cannot be unit-tested here.
+        // What *is* tested: the exact JSON shape serialise()/exportTask() produce for a
+        // custom-angle dynamic schedule round-trips through JSON.stringify/JSON.parse losslessly,
+        // and that shape is accepted by validateOpt()/createTask() unchanged - which is the same
+        // code path deserialise() uses on restart, so if this passes, restore is a JSON.parse away
+        // from working. (Confirmed manually end-to-end with real file persistence too - see PR notes.)
+        it('produces a JSON-safe, round-trippable shape for a custom-angle dynamic schedule, and that shape is re-creatable', async function () {
+            const nodeId = 'shapeAngle1'
+            const flow = [
+                { id: 'helperCmd', type: 'helper' },
+                {
+                    id: nodeId,
+                    type: 'cronplus',
+                    name: 'shape-angle-test',
+                    outputField: 'payload',
+                    timeZone: '',
+                    persistDynamic: false,
+                    commandResponseMsgOutput: 'output1',
+                    outputs: 1,
+                    options: [],
+                    wires: [['helperCmd']]
+                }
+            ]
+            await helper.load(cronplusNode, flow)
+            const node = helper.getNode(nodeId)
+            const helperCmd = helper.getNode('helperCmd')
+
+            node.receive({
+                payload: {
+                    command: 'add',
+                    name: 'dynAngle1',
+                    topic: 'dynAngle1',
+                    expressionType: 'solar',
+                    location: '54.9992500,-1.4170300',
+                    solarType: 'selected',
+                    solarEvents: 'angle:-4:rise',
+                    offset: 0,
+                    payloadType: 'default'
+                }
+            })
+            await sleep(50)
+
+            const listPromise = new Promise(resolve => helperCmd.once('input', resolve))
+            node.receive({ payload: { command: 'list', name: 'dynAngle1' } })
+            const listResult = await listPromise
+            const exportedConfig = listResult.payload.result.config
+
+            // this is exactly the shape serialise() would write to disk/context for this schedule
+            exportedConfig.should.have.property('expressionType', 'solar')
+            exportedConfig.should.have.property('solarType', 'selected')
+            exportedConfig.should.have.property('solarEvents', 'angle:-4:rise')
+
+            // the human-facing description must be the friendly label, not the raw token -
+            // this is what the dynamic-schedules viewer and node status text render
+            listResult.payload.result.status.should.have.property('nextDescription').which.is.a.String()
+            listResult.payload.result.status.nextDescription.should.match(/below the horizon/)
+            listResult.payload.result.status.nextDescription.should.not.match(/angle:-4:rise/)
+
+            // simulate what deserialise() does: JSON round-trip the exported config, then feed
+            // it back in as a fresh 'add' (same code path createTask()/validateOpt() take on
+            // restart) - if this is accepted and produces the same schedule, restore will work
+            const roundTripped = JSON.parse(JSON.stringify(exportedConfig))
+            node.receive({ payload: { command: 'remove', name: 'dynAngle1' } })
+            await sleep(50)
+            node.receive({ payload: { command: 'add', ...roundTripped } })
+            await sleep(50)
+
+            const listPromise2 = new Promise(resolve => helperCmd.once('input', resolve))
+            node.receive({ payload: { command: 'list', name: 'dynAngle1' } })
+            const listResult2 = await listPromise2
+            listResult2.payload.result.config.should.have.property('solarEvents', 'angle:-4:rise')
+            listResult2.payload.result.status.nextDescription.should.match(/below the horizon/)
+        })
+    })
+
     describe('DST transition handling (Debian cron rules)', function () {
         // Jobs whose minute or hour field starts with `*` ("wildcard jobs") keep
         // their real-time interval across a DST change, so they also run during


### PR DESCRIPTION
Expand sun based events to include a custom angle above or below the horizon.

Below is screenshots of the UI with the proposed changes
<img width="479" height="84" alt="screenshot-cron-plus-node" src="https://github.com/user-attachments/assets/b0a4b762-8d9d-4c20-8611-49116a28a586" />
<img width="681" height="873" alt="screenshot-custom-angle" src="https://github.com/user-attachments/assets/3f881767-f4f6-44da-84a3-310ed61fafb8" />

Previously filed against the main branch as #134