### PR TITLE
Expose sun angles as a trigger option

### DIFF
--- a/cronplus.html
+++ b/cronplus.html
@@ -432,6 +432,20 @@ copies or substantial portions of the Software.
         }
     }
 
+    // Custom solar-angle schedules (solarType 'customRising'/'customSetting') hold their angle,
+    // in degrees, as the typedInput's own value for those two types - no CSV, no encoded string,
+    // just a plain number, validated with typedInput's own validate hook (see solarEventsField
+    // below) so a bad value turns the box red as you type instead of failing silently on save.
+    const CUSTOM_ANGLE_VALUE_REGEX = /^-?\d+(?:\.\d+)?$/
+    function validateCustomAngleValue (value, _opt) {
+        const v = String(value == null ? '' : value).trim()
+        if (v === '') return 'Enter a number of degrees (-90 to 90)'
+        if (!CUSTOM_ANGLE_VALUE_REGEX.test(v)) return 'Enter a number of degrees (-90 to 90)'
+        const n = parseFloat(v)
+        if (n < -90 || n > 90) return 'Must be between -90 and 90 degrees'
+        return true
+    }
+
     function showSidebarHelpPanel () {
         if (RED.sidebar.help) {
             RED.sidebar.help.show()//  >= V1.1.0
@@ -756,13 +770,18 @@ copies or substantial portions of the Software.
                                     return false
                                 }
                             } else if (value[i].expressionType === 'solar') {
-                                if (value[i].solarType !== 'all' && value[i].solarType !== 'selected') {
-                                    console.warn("cron-plus: validation error - solarType is not 'all' or 'selected'")
+                                if (!['all', 'selected', 'customRising', 'customSetting'].includes(value[i].solarType)) {
+                                    console.warn("cron-plus: validation error - solarType is not 'all', 'selected', 'customRising' or 'customSetting'")
                                     // $("#node-input-option-container > li:nth-child(" + (i+1) + ")  .node-input-option-solarType").addClass("input-error");
                                     return false
                                 }
                                 if (value[i].solarType === 'selected' && !value[i].solarEvents) {
                                     console.warn('cron-plus: validation error - solarEvents missing')
+                                    return false
+                                }
+                                if ((value[i].solarType === 'customRising' || value[i].solarType === 'customSetting') &&
+                                    validateCustomAngleValue(value[i].solarEvents) !== true) {
+                                    console.warn('cron-plus: validation error - solarEvents is not a valid custom angle (-90 to 90)')
                                     return false
                                 }
                             } else if (value[i].expressionType === 'lunar') {
@@ -1714,11 +1733,46 @@ copies or substantial portions of the Software.
                             icon: 'fa fa-sun-o',
                             hasValue: false,
                             showLabel: true
+                        },
+                        {
+                            value: 'customRising',
+                            label: 'Custom Rising Angle',
+                            title: 'Custom Rising Angle',
+                            icon: 'fa fa-arrow-circle-o-up',
+                            showLabel: true,
+                            hasValue: true,
+                            validate: validateCustomAngleValue
+                        },
+                        {
+                            value: 'customSetting',
+                            label: 'Custom Setting Angle',
+                            title: 'Custom Setting Angle',
+                            icon: 'fa fa-arrow-circle-o-down',
+                            showLabel: true,
+                            hasValue: true,
+                            validate: validateCustomAngleValue
                         }
                     ]
                 })
                 solarEventsField.typedInput('type', option.solarType || 'all')
                 solarEventsField.typedInput('value', option.solarEvents || '')// added as setting value on invocation doesnt seem to set the "2 selected" text of the widget!
+                // the two custom-angle types share hasValue's free-text box with every other
+                // type, so switching in leaves whatever was typed/selected before (e.g. a
+                // "sunrise,sunset" CSV from "Selected Solar Events"). Clear it out unless it's
+                // already a usable angle, and swap the placeholder so it doesn't still read
+                // "select solar events" while degrees are expected.
+                solarEventsField.on('typedinputtypechange', function () {
+                    const currentType = solarEventsField.typedInput('type')
+                    const $visibleInput = solarEventsDiv.find('.red-ui-typedInput-input')
+                    if (currentType === 'customRising' || currentType === 'customSetting') {
+                        $visibleInput.attr('placeholder', 'degrees, -90 to 90')
+                        if (!CUSTOM_ANGLE_VALUE_REGEX.test(String(solarEventsField.typedInput('value') || '').trim())) {
+                            solarEventsField.typedInput('value', '')
+                        }
+                    } else {
+                        $visibleInput.attr('placeholder', 'select solar events')
+                    }
+                })
 
                 // generate the lunar events field (occupies the same slot as solar events - visibility is switched by schedule type)
                 const lunarEventsDiv = $('<div/>', { style: solarEventsStyle }).appendTo(cell2Solar)
@@ -2514,6 +2568,14 @@ function onSchedulesExpandCompress () {
                 <tr><td>nightStart</td><td>astronomical dusk / night start</td><td>astronomical twilight ends, night starts (-18°)</td></tr>
                 <tr><td>nadir</td><td>solar midnight</td><td>when the sun is closest to nadir and the night is equidistant from dusk and dawn</td></tr>
             </table>
+            <p>
+                <b>Custom sun angle</b> - if none of the presets above are the angle you need, select
+                <i>Custom Rising Angle</i> or <i>Custom Setting Angle</i> from the type dropdown
+                instead of <i>Selected Solar Events</i>, then enter the angle (in degrees, -90 to 90,
+                above (+) or below (-) the horizon) directly into the box. Choosing the type already
+                tells cron-plus which direction you mean, so the angle itself is all that's needed;
+                a bad value turns the box red as you type.
+            </p>
         </div>
         <h4 id="cron-plus-lunar-events-info">Schedules - Lunar Events</h4>
         <div style="padding-left: 15px">
@@ -2641,8 +2703,8 @@ function onSchedulesExpandCompress () {
                         <li>name: (string|required) This will identify schedule</li>
                         <li>topic: (string|required) This will be used as the topic when the schedule triggers</li>
                         <li>expressionType: (string|required) specify the schedule type. Set to "solar" for solar events</li>
-                        <li>solarType: (string|required) specify the events to fire.  Accepted values are "all" or "selected"</li>
-                        <li>solarEvents: (string|optional) specify the events to fire. Only required when solarType == "selected". Accepted values are listed under <b>Schedules - Solar Events</b> <a href="#cron-plus-solar-events-info">see above</a> </li>
+                        <li>solarType: (string|required) specify the events to fire.  Accepted values are "all", "selected", "customRising" or "customSetting"</li>
+                        <li>solarEvents: (string|optional) specify the events to fire. Only required when solarType == "selected" (a CSV of event names, see <b>Schedules - Solar Events</b> <a href="#cron-plus-solar-events-info">above</a>) or solarType == "customRising"/"customSetting" (a single number of degrees, -90 to 90, above (+) or below (-) the horizon)</li>
                         <li>location: (string|required) longitude latitude, DNS, DMM or GPS coordinates for sunrise or sunset</li>
                         <li>offset: (number|optional) number of minutes to offset a sunrise or sunset</li>
                         <li>payloadType: (string|optional) The payload type (e.g. 'default', 'flow', 'global', 'str', 'num', 'bool', 'json', 'bin', 'date' or 'env')</li>
@@ -2770,6 +2832,15 @@ msg.payload = "name"; //  name of the schedule</code></pre>
   "location": "54.9992500,-1.4170300",
   "solarType": "selected",
   "solarEvents": "civilDawn,sunrise,sunset,civilDusk",
+  "timeZone": "Europe/London"
+}</code></pre>
+                Example : cmd payload to describe a custom sun angle (fires as the sun rises through 4° below the horizon)...<br>
+    <pre class="cron-plus-code"><code>{
+  "command": "describe",
+  "expressionType": "solar",
+  "location": "54.9992500,-1.4170300",
+  "solarType": "customRising",
+  "solarEvents": "-4",
   "timeZone": "Europe/London"
 }</code></pre>
                 <p><i>Details...</i><br>

--- a/cronplus.js
+++ b/cronplus.js
@@ -51,6 +51,50 @@ const PERMITTED_LUNAR_EVENTS = [
     'set'
 ]
 
+// Custom solar-angle schedules (solarType 'customRising'/'customSetting') fire when the sun
+// crosses a user-specified angle above/below the horizon, in a given direction. Unlike the
+// PERMITTED_SOLAR_EVENTS presets, direction lives in solarType itself and the angle (in degrees,
+// -90 to 90) is the *only* thing solarEvents holds for these two types - no string encoding to
+// keep in sync with the editor, just a plain number.
+const CUSTOM_SOLAR_TYPES = ['customRising', 'customSetting']
+
+/**
+ * Human friendly description of a custom solar-angle schedule, e.g. "sun rising 4° below the horizon"
+ * @param {string} solarType 'customRising' or 'customSetting'
+ * @param {number|string} angleDegrees degrees above (positive) or below (negative) the horizon
+ * @returns {string}
+ */
+function describeCustomAngle (solarType, angleDegrees) {
+    const direction = solarType === 'customRising' ? 'rising' : 'setting'
+    const angle = parseFloat(angleDegrees)
+    const position = angle === 0 ? 'at the horizon' : (angle > 0 ? `${angle}° above the horizon` : `${Math.abs(angle)}° below the horizon`)
+    return `sun ${direction} ${position}`
+}
+
+// Cache of custom angles already registered with SunCalc. SunCalc.addTime() simply pushes a new
+// entry onto its internal (module scoped) `times` array every time it's called, with no
+// de-duplication, so registering the same angle repeatedly (e.g. every time a schedule is
+// (re)computed) would leak memory and duplicate work - this cache prevents that.
+const registeredSolarAngles = new Map()
+
+/**
+ * Ensure a custom solar angle is registered with SunCalc, returning the generated rise/set
+ * property names that SunCalc.getTimes() will then populate for that angle.
+ * @param {number} angle Angle in degrees above (positive) or below (negative) the horizon
+ * @returns {{riseName: string, setName: string}}
+ */
+function ensureCustomSolarAngleRegistered (angle) {
+    const key = angle.toFixed(4)
+    let names = registeredSolarAngles.get(key)
+    if (!names) {
+        const safeKey = key.replace('-', 'n').replace('.', 'p')
+        names = { riseName: `customAngle_${safeKey}_rise`, setName: `customAngle_${safeKey}_set` }
+        SunCalc.addTime(angle, names.riseName, names.setName)
+        registeredSolarAngles.set(key, names)
+    }
+    return names
+}
+
 // accepted commands using topic as the command & (in compatible cases, the payload is the schedule name)
 // commands not supported by topic are : add/update & describe
 const controlTopics = [
@@ -163,11 +207,18 @@ function validateOpt (opt, permitDefaults = true) {
                 throw new Error(`Schedule '${opt.name}' - location property missing`)
             }
         }
-        if (isSolar && opt.solarType !== 'selected' && opt.solarType !== 'all') {
-            throw new Error(`Schedule '${opt.name}' - solarType property invalid or missing. Must be either "all" or "selected"`)
+        if (isSolar && opt.solarType !== 'selected' && opt.solarType !== 'all' && !CUSTOM_SOLAR_TYPES.includes(opt.solarType)) {
+            throw new Error(`Schedule '${opt.name}' - solarType property invalid or missing. Must be one of "all", "selected", "customRising" or "customSetting"`)
         }
         if (isLunar && opt.lunarType !== 'selected' && opt.lunarType !== 'all') {
             throw new Error(`Schedule '${opt.name}' - lunarType property invalid or missing. Must be either "all" or "selected"`)
+        }
+        if (isSolar && CUSTOM_SOLAR_TYPES.includes(opt.solarType)) {
+            const angle = parseFloat(opt.solarEvents)
+            if (opt.solarEvents === undefined || opt.solarEvents === null || opt.solarEvents === '' || isNaN(angle) || angle < -90 || angle > 90) {
+                throw new Error(`Schedule '${opt.name}' - solarEvents property must be a number of degrees between -90 and 90 when solarType is '${opt.solarType}'`)
+            }
+            return
         }
         const _type = isSolar ? opt.solarType : opt.lunarType
         const events = isSolar ? opt.solarEvents : opt.lunarEvents
@@ -330,10 +381,10 @@ function _describeExpression (expression, expressionType, timeZone, offset, sola
             const offset = isNumber(opt.offset) ? parseInt(opt.offset) : 0
             const nowOffset = new Date(now.getTime() - offset * 60000)
             if (isSolar) {
-                result = getSolarTimes(pos.lat, pos.lon, 0, solarEvents, now, offset)
+                result = getSolarTimes(pos.lat, pos.lon, 0, solarEvents, now, offset, solarType)
                 // eslint-disable-next-line eqeqeq
                 if (opts.includeSolarStateOffset && offset != 0) {
-                    const ssOffset = getSolarTimes(pos.lat, pos.lon, 0, solarEvents, nowOffset, 0)
+                    const ssOffset = getSolarTimes(pos.lat, pos.lon, 0, solarEvents, nowOffset, 0, solarType)
                     result.solarStateOffset = ssOffset.solarState
                 }
             } else if (isLunar) {
@@ -376,6 +427,12 @@ function _describeExpression (expression, expressionType, timeZone, offset, sola
             if (expressionType === 'solar') {
                 if (solarType === 'all') {
                     result.description = 'All Solar Events'
+                } else if (CUSTOM_SOLAR_TYPES.includes(solarType)) {
+                    const label = describeCustomAngle(solarType, solarEvents)
+                    result.description = "Solar Events: '" + label + "'"
+                    if (result.nextEvent) {
+                        result.prettyNext = label + ` in ${prettyMs(ms, { secondsDecimalDigits: 0, verbose: true })}`
+                    }
                 } else {
                     result.description = "Solar Events: '" + solarEvents.split(',').join(', ') + "'"
                 }
@@ -573,7 +630,7 @@ function parseSolarTimes (opt) {
     const offset = opt.offset ? parseInt(opt.offset) : 0
     const date = opt.date ? new Date(opt.date) : new Date()
     const events = opt.solarType === 'all' ? PERMITTED_SOLAR_EVENTS : opt.solarEvents
-    const result = getSolarTimes(pos.lat, pos.lon, 0, events, date, offset)
+    const result = getSolarTimes(pos.lat, pos.lon, 0, events, date, offset, opt.solarType)
     const task = parseDateSequence(result.eventTimes.map((o) => o.timeOffset))
     task.solarEventTimes = result
     return task
@@ -616,7 +673,10 @@ function getMoonData (dateValue, lat, lng) {
     }, pos)
 }
 
-function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offset = 0) {
+function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offset = 0, solarType = 'selected') {
+    if (solarType === 'customRising' || solarType === 'customSetting') {
+        return getCustomAngleSolarTimes(lat, lng, solarEvents, startDate, offset, solarType)
+    }
     // performance.mark('Start');
     const solarEventsPast = [...PERMITTED_SOLAR_EVENTS]
     const solarEventsFuture = [...PERMITTED_SOLAR_EVENTS]
@@ -843,6 +903,59 @@ function getSolarTimes (lat, lng, elevation, solarEvents, startDate = null, offs
         stateObject.dusk = stateObject.direction === 'fall' && stateObject.civilTwilight
         stateObject.morningGoldenHour = stateObject.direction === 'rise' && stateObject.goldenHour
         stateObject.eveningGoldenHour = stateObject.direction === 'fall' && stateObject.goldenHour
+    }
+}
+
+/**
+ * Compute the next occurrence (and, in a JSON-friendly shape matching getSolarTimes()'s return
+ * value, the current solarState) of the sun crossing a custom angle above/below the horizon, in
+ * a given direction. Used for solarType 'customRising'/'customSetting' - kept as a separate,
+ * dedicated computation rather than folded into getSolarTimes()'s PERMITTED_SOLAR_EVENTS scan
+ * since there is only ever one event of interest here (no day/night state to track across a
+ * whole set of presets).
+ * @param {number} lat
+ * @param {number} lng
+ * @param {number|string} angleDegrees degrees above (positive) or below (negative) the horizon
+ * @param {Date|string|null} startDate
+ * @param {number} offset minutes offset applied to the computed time
+ * @param {'customRising'|'customSetting'} solarType
+ * @returns {{solarState: object, nextEvent: (string|null), nextEventTime: (Date|null), nextEventTimeOffset: (Date|null), eventTimes: Array}}
+ */
+function getCustomAngleSolarTimes (lat, lng, angleDegrees, startDate, offset, solarType) {
+    const angle = parseFloat(angleDegrees)
+    const direction = solarType === 'customRising' ? 'rise' : 'set'
+    const eventName = solarType === 'customRising' ? 'customAngleRise' : 'customAngleSet'
+    const names = ensureCustomSolarAngleRegistered(angle)
+    const internalName = direction === 'rise' ? names.riseName : names.setName
+
+    offset = isNumber(offset) ? parseInt(offset) : 0
+    startDate = startDate ? new Date(startDate) : new Date()
+
+    // only a forward scan is needed - unlike getSolarTimes() there's no day/night state to
+    // derive from past occurrences, just the single next time this angle is crossed
+    const scanDate = new Date(startDate.toDateString())
+    scanDate.setDate(scanDate.getDate() - 1) // back one day to catch times ahead of current day
+    let loopMonitor = 0
+    let futureEvent = null
+    while (loopMonitor < 183 && !futureEvent) {
+        loopMonitor++
+        const times = getSunTimes(scanDate, lat, lng)
+        const seTime = times[internalName]
+        if (seTime && isValidDateObject(seTime)) {
+            const seTimeOffset = new Date(seTime.getTime() + offset * 60000)
+            if (isValidDateObject(seTimeOffset) && seTimeOffset > startDate) {
+                futureEvent = { event: eventName, time: seTime, timeOffset: seTimeOffset }
+            }
+        }
+        scanDate.setDate(scanDate.getDate() + 1)
+    }
+
+    return {
+        solarState: {},
+        nextEvent: futureEvent ? futureEvent.event : null,
+        nextEventTime: futureEvent ? futureEvent.time : null,
+        nextEventTimeOffset: futureEvent ? futureEvent.timeOffset : null,
+        eventTimes: futureEvent ? [futureEvent] : []
     }
 }
 
@@ -1201,16 +1314,25 @@ module.exports = function (RED) {
                 const nx = (t._expression || t._sequence)
                 node.nextDate = nx.nextDate(now)
                 node.nextEvent = t.name
+                node.nextEventDisplay = t.name
                 node.nextIndicator = indicator
                 if (t.node_solarEventTimes && t.node_solarEventTimes.nextEvent) {
                     node.nextEvent = t.node_solarEventTimes.nextEvent
+                    // node.nextEvent stays the raw machine identifier (it also becomes
+                    // msg.cronplus.status.solarEvent) - only the status-text display gets the
+                    // friendly label, built directly from solarType/solarEvents (no encoding to decode)
+                    node.nextEventDisplay = CUSTOM_SOLAR_TYPES.includes(t.node_solarType)
+                        ? describeCustomAngle(t.node_solarType, t.node_solarEvents)
+                        : node.nextEvent
                 }
                 if (t.node_lunarEventTimes && t.node_lunarEventTimes.nextEvent) {
                     node.nextEvent = t.node_lunarEventTimes.nextEvent
+                    node.nextEventDisplay = node.nextEvent
                 }
             } else {
                 node.nextDate = null
                 node.nextEvent = ''
+                node.nextEventDisplay = ''
                 node.nextIndicator = ''
             }
         }
@@ -2136,7 +2258,7 @@ module.exports = function (RED) {
                 const indicator = node.nextIndicator || 'dot'
                 if (node.nextDate) {
                     const d = formatShortDateTimeWithTZ(node.nextDate, node.timeZone) || 'Never'
-                    node.status({ fill: 'blue', shape: indicator, text: (node.nextEvent || 'Next') + ': ' + d })
+                    node.status({ fill: 'blue', shape: indicator, text: (node.nextEventDisplay || 'Next') + ': ' + d })
                 } else if (node.tasks && node.tasks.length) {
                     node.status({ fill: 'grey', shape: indicator, text: 'All stopped' })
                 } else {

--- a/test/test1_spec.js
+++ b/test/test1_spec.js
@@ -794,6 +794,75 @@ describe('cron-plus Node', function () {
             const result = await resultPromise
             commandChecker(result, test)
         })
+        it('describe a custom rising solar angle (-4 degrees)', async function (t) {
+            const test = {
+                description: t.name,
+                send: { payload: { command: 'describe', expressionType: 'solar', location: '54.9992500,-1.4170300', solarType: 'customRising', solarEvents: '-4', timeZone: 'Europe/London' } },
+                expected: { command: 'describe', propertyValues: [['payload.result.description', 'string', "Solar Events: 'sun rising 4° below the horizon'"]] }
+            }
+            const resultPromise = new Promise(resolve => {
+                helperNodeCommandResponses.on('input', (msg) => {
+                    resolve(msg)
+                })
+            })
+            testNode.receive(test.send)
+            const result = await resultPromise
+            commandChecker(result, test)
+            result.payload.result.should.have.property('nextEvent', 'customAngleRise')
+            result.payload.result.should.have.property('nextEventTimeOffset').which.is.a.Date()
+        })
+        it('describe a custom setting solar angle (6.5 degrees)', async function (t) {
+            const test = {
+                description: t.name,
+                send: { payload: { command: 'describe', expressionType: 'solar', location: '54.9992500,-1.4170300', solarType: 'customSetting', solarEvents: '6.5', timeZone: 'Europe/London' } },
+                expected: { command: 'describe', propertyValues: [['payload.result.description', 'string', "Solar Events: 'sun setting 6.5° above the horizon'"]] }
+            }
+            const resultPromise = new Promise(resolve => {
+                helperNodeCommandResponses.on('input', (msg) => {
+                    resolve(msg)
+                })
+            })
+            testNode.receive(test.send)
+            const result = await resultPromise
+            commandChecker(result, test)
+            result.payload.result.should.have.property('nextEvent', 'customAngleSet')
+        })
+        it('should reject adding a schedule with an out-of-range custom solar angle', async function () {
+            testNode.receive({
+                payload: {
+                    command: 'add',
+                    name: 'dynBadAngle',
+                    topic: 'dynBadAngle',
+                    expressionType: 'solar',
+                    location: '54.9992500,-1.4170300',
+                    solarType: 'customRising',
+                    solarEvents: '120',
+                    payloadType: 'default',
+                    limit: 1
+                }
+            })
+            await sleep(50) // let it unwind
+            const warnCall = testNode.warn.getCalls().find(c => c.args[0] && String(c.args[0].message || c.args[0]).includes('degrees between -90 and 90'))
+            should(warnCall).not.be.undefined()
+        })
+        it('should reject adding a schedule with a non-numeric custom solar angle', async function () {
+            testNode.receive({
+                payload: {
+                    command: 'add',
+                    name: 'dynBadAngle2',
+                    topic: 'dynBadAngle2',
+                    expressionType: 'solar',
+                    location: '54.9992500,-1.4170300',
+                    solarType: 'customSetting',
+                    solarEvents: 'not-a-number',
+                    payloadType: 'default',
+                    limit: 1
+                }
+            })
+            await sleep(50)
+            const warnCall = testNode.warn.getCalls().find(c => c.args[0] && String(c.args[0].message || c.args[0]).includes('degrees between -90 and 90'))
+            should(warnCall).not.be.undefined()
+        })
         it('describe lunar events for a location', async function (t) {
             const test = {
                 description: t.name,
@@ -1308,6 +1377,82 @@ describe('cron-plus Node', function () {
             const result = await resultPromise
             result.should.have.property('payload', 'schedule1')
             result.should.have.property('topic', 'trigger')
+        })
+    })
+
+    describe('custom solar angle schedules - end to end regression', function () {
+        // this describe block deliberately does NOT nest inside 'extended tests' - it needs its
+        // own isolated flow (rather than the large shared testNode flow used above) so this
+        // schedule is the *only* task on the node and node.status() always reflects it, with no
+        // risk of another schedule elsewhere in the shared flow racing to be "next" and masking
+        // the result. Nesting inside 'extended tests' would double-load the shared flow (which
+        // its own beforeEach already loaded) and fail with a "already wrapped" sinon error.
+        it('correctly runs a dynamically added custom-angle solar schedule end to end', async function () {
+            const flow = [
+                { id: 'helperCmd2', type: 'helper' },
+                {
+                    id: 'angleEndToEndNode',
+                    type: 'cronplus',
+                    name: 'angle-end-to-end',
+                    outputField: 'payload',
+                    timeZone: '',
+                    persistDynamic: false,
+                    commandResponseMsgOutput: 'output1',
+                    outputs: 1,
+                    options: [],
+                    wires: [['helperCmd2']]
+                }
+            ]
+            await helper.load(cronplusNode, flow)
+            const node = helper.getNode('angleEndToEndNode')
+            const helperCmd = helper.getNode('helperCmd2')
+
+            node.receive({
+                payload: {
+                    command: 'add',
+                    name: 'dynGoodAngle',
+                    topic: 'dynGoodAngle',
+                    expressionType: 'solar',
+                    location: '54.9992500,-1.4170300',
+                    solarType: 'customRising',
+                    solarEvents: '-4',
+                    offset: 0,
+                    payloadType: 'default'
+                }
+            })
+            await sleep(50)
+
+            const noWarnings = node.warn.getCalls().filter(c => c.args[0] && String(c.args[0].message || c.args[0]).includes('degrees between -90 and 90'))
+            noWarnings.should.have.length(0)
+
+            // 'status' forces an immediate (non-debounced) node.status() update - this is the
+            // real regression check: parseSolarTimes() (the function that builds the *actual*
+            // scheduled date sequence used to fire the schedule) must pass solarType through to
+            // getSolarTimes(), otherwise the custom angle is silently treated as an empty/invalid
+            // "selected events" CSV, the task ends up with no future date, and node.status()
+            // never reports a valid (fill: 'blue') next-fire status - the schedule never fires.
+            // Checking the 'list'/'describe' command output is NOT sufficient here: those
+            // independently recompute the description fresh each time and would report a
+            // plausible result even when the actual scheduled task itself is broken.
+            node.status.resetHistory()
+            node.receive({ payload: { command: 'status', name: 'dynGoodAngle' } })
+            await sleep(50)
+            const matchingStatus = node.status.getCalls().find(c => c.args[0] && c.args[0].fill === 'blue' &&
+                typeof c.args[0].text === 'string' && /below the horizon/.test(c.args[0].text))
+            should(matchingStatus).not.be.undefined()
+
+            const resultPromise = new Promise(resolve => {
+                helperCmd.once('input', (msg) => resolve(msg))
+            })
+            node.receive({ payload: { command: 'list', name: 'dynGoodAngle' } })
+            const result = await resultPromise
+            result.payload.result.should.have.property('config').which.is.an.Object()
+            result.payload.result.config.should.have.property('solarType', 'customRising')
+            result.payload.result.config.should.have.property('solarEvents', '-4')
+            result.payload.result.should.have.property('status').which.is.an.Object()
+            result.payload.result.status.should.have.property('nextDescription').which.is.a.String()
+            result.payload.result.status.nextDescription.should.match(/below the horizon/)
+            result.payload.result.status.should.have.property('nextDate').which.is.not.null()
         })
     })
 })


### PR DESCRIPTION
Previously filed against the main branch as #134 and then filed against the feat-v3-filter branch as #137. All feedback from both PRs has been taken into consideration before submitting this PR.

This PR expands sun based events to include a custom angle, values of +/-90 are allowed which represents 90 degrees above or below the horizon.

I originally attempted to use an existing sun rise/set option with an offset in minutes but there ended up too much drift from the desired time of day.

I tested dynamic settings using the following payload:

```
{
    "command": "add",
    "name": "customDawn",
    "topic": "customDawn",
    "expressionType": "solar",
    "location": "-33.8567, 151.2153",
    "solarType": "customRising",
    "solarEvents": "-4"
}
```

Below is screenshots of the UI with the proposed changes
<img width="696" height="102" alt="screenshot-cron-plus-node-dynamic-test" src="https://github.com/user-attachments/assets/e8840011-491c-4ea8-b21a-568f21fdda84" />
<img width="652" height="69" alt="screenshot-cron-plus-node" src="https://github.com/user-attachments/assets/21d7a4ed-8a33-4fc2-9551-eaf67a98a1dc" />
<img width="682" height="845" alt="screenshot-cron-plus-node-settings" src="https://github.com/user-attachments/assets/efd8a7b5-a604-4439-844d-0b76e45582d7" />

I also tested using a location setting stored as an environmental variable set on the cron plus node with no location in the payload which failed. I plan to file a separate PR for that.