### PR TITLE
fix: sun/moon position, named dates, and several silent misparses in when gate conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ Type the condition in plain English; a live "understanding" line below the field
 * `january 2027`, `2027 to 2029`, `first monday of the year`, `2nd tuesday of 2028`, `first monday of january`, `after 2027`/`before 2027` (unbounded, unlike months)
 * `when day is odd`, `on even months`, `on even years`
 * `christmas eve`, `day before christmas`, `4 days after christmas`, `1 month before christmas`, `within 2 days of christmas`
+* other fixed dates (same everywhere, no moveable feasts or country-varying rules): `valentines day`, `groundhog day`, `st patricks day`, `april fools day`, `earth day`, `may day`, `boxing day` (each also works with `eve`, `day before`, etc.)
 * `between 9am and 5pm`, `before noon`, `between 10pm and 6am` (overnight)
+* `morning` (00:00-12:00), `afternoon` (12:00-18:00), `evening` (18:00-24:00) - fixed clock hours, not solar; the understanding line points to the sun-relative equivalent (`dawn`/`sunrise`, `afternoon sun`/`golden hour`, `dusk`/`twilight`)
 * `between 15 minutes and 30 minutes past the hour`, `quarter past`, `half past`, `ten past`, `5 to` (every hour; `quarter past five` is the clock time 05:15)
 * `is night`, `after dark`, `golden hour`, `sun rising`, `during daylight`
 * `after sunset`, `before sunrise`, `2 hours after sunset`, `within 30 minutes of sunrise`, `between sunset and sunrise`
 * `when the moon is visible`, `full moon`, `blue moon` (second full moon of a calendar month), `seasonal blue moon` (third full moon in a season of four), `moon more than 50% illuminated`, `moon is 90% illuminated` (bare percentages mean "at least")
 * `sun is between 10 and 12 degrees`, `sun above 30 degrees`, `sun is high`/`sun is low`, `moon is high`/`moon is low`
-* `sun azimuth is between 134 and 138 degrees`, `moon azimuth between 60 and 90` (compass bearing from North, 0-360; wraps through north, e.g. `between 350 and 10`)
+* `sun azimuth is between 134 and 138 degrees`, `moon azimuth between 60 and 90` (compass bearing from North, 0-360; wraps through north, e.g. `sun azimuth between 350 and 10`)
+* combining altitude and azimuth: `sun azimuth is between 134 and 138 and sun altitude is between 0.9 and 2.2` (Newgrange's midwinter sunrise alignment) - `sun` must be named on both clauses, "...and its altitude..." has no sun/moon context of its own
 * `>` and `<` work as symbols for "above"/"below"/"more than"/"less than", e.g. `sun > 30 degrees`, `moon < 50% illuminated`, `> 4pm` (same as `after 4pm`), `at least 4pm`
 * combined: `on weekdays and during daylight`, `on weekends or after sunset`, `weekends or evenings except tuesday`
 * brackets group mixed and/or: `(last day of the month or wednesday) and after 10pm` - without brackets `and` binds tighter than `or`, and the understanding line always shows the grouping it settled on

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Type the condition in plain English; a live "understanding" line below the field
 
 * `on saturday only`, `weekdays`, `mon-wed`, `not on tuesday`
 * `first monday of the month`, `3rd tuesday of the month`, `last friday of the month`, `last day of the month`, `last day of the week` (weeks start Monday; the understanding line shows which day it resolved to)
-* `in december`, `june to august`, `on the 1st of the month`, `christmas day`
-* `january 2027`, `2027 to 2029`, `first monday of the year`, `2nd tuesday of 2028`, `first monday of january`
+* `in december`, `june to august`, `on the 1st of the month`, `christmas day`, `after march`/`before march` (excludes march itself either way)
+* `january 2027`, `2027 to 2029`, `first monday of the year`, `2nd tuesday of 2028`, `first monday of january`, `after 2027`/`before 2027` (unbounded, unlike months)
 * `when day is odd`, `on even months`, `on even years`
 * `christmas eve`, `day before christmas`, `4 days after christmas`, `1 month before christmas`, `within 2 days of christmas`
 * `between 9am and 5pm`, `before noon`, `between 10pm and 6am` (overnight)
@@ -103,7 +103,7 @@ Type the condition in plain English; a live "understanding" line below the field
 * `when the moon is visible`, `full moon`, `blue moon` (second full moon of a calendar month), `seasonal blue moon` (third full moon in a season of four), `moon more than 50% illuminated`, `moon is 90% illuminated` (bare percentages mean "at least")
 * `sun is between 10 and 12 degrees`, `sun above 30 degrees`, `sun is high`/`sun is low`, `moon is high`/`moon is low`
 * `sun azimuth is between 134 and 138 degrees`, `moon azimuth between 60 and 90` (compass bearing from North, 0-360; wraps through north, e.g. `between 350 and 10`)
-* `>` and `<` work as symbols wherever "above"/"below"/"more than"/"less than" already do, e.g. `sun > 30 degrees`, `moon < 50% illuminated`
+* `>` and `<` work as symbols for "above"/"below"/"more than"/"less than", e.g. `sun > 30 degrees`, `moon < 50% illuminated`, `> 4pm` (same as `after 4pm`), `at least 4pm`
 * combined: `on weekdays and during daylight`, `on weekends or after sunset`, `weekends or evenings except tuesday`
 * brackets group mixed and/or: `(last day of the month or wednesday) and after 10pm` - without brackets `and` binds tighter than `or`, and the understanding line always shows the grouping it settled on
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Type the condition in plain English; a live "understanding" line below the field
 * `when the moon is visible`, `full moon`, `blue moon` (second full moon of a calendar month), `seasonal blue moon` (third full moon in a season of four), `moon more than 50% illuminated`, `moon is 90% illuminated` (bare percentages mean "at least")
 * `sun is between 10 and 12 degrees`, `sun above 30 degrees`, `sun is high`/`sun is low`, `moon is high`/`moon is low`
 * `sun azimuth is between 134 and 138 degrees`, `moon azimuth between 60 and 90` (compass bearing from North, 0-360; wraps through north, e.g. `between 350 and 10`)
+* `>` and `<` work as symbols wherever "above"/"below"/"more than"/"less than" already do, e.g. `sun > 30 degrees`, `moon < 50% illuminated`
 * combined: `on weekdays and during daylight`, `on weekends or after sunset`, `weekends or evenings except tuesday`
 * brackets group mixed and/or: `(last day of the month or wednesday) and after 10pm` - without brackets `and` binds tighter than `or`, and the understanding line always shows the grouping it settled on
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Type the condition in plain English; a live "understanding" line below the field
 * `after sunset`, `before sunrise`, `2 hours after sunset`, `within 30 minutes of sunrise`, `between sunset and sunrise`
 * `when the moon is visible`, `full moon`, `blue moon` (second full moon of a calendar month), `seasonal blue moon` (third full moon in a season of four), `moon more than 50% illuminated`, `moon is 90% illuminated` (bare percentages mean "at least")
 * `sun is between 10 and 12 degrees`, `sun above 30 degrees`, `sun is high`/`sun is low`, `moon is high`/`moon is low`
+* `sun azimuth is between 134 and 138 degrees`, `moon azimuth between 60 and 90` (compass bearing from North, 0-360; wraps through north, e.g. `between 350 and 10`)
 * combined: `on weekdays and during daylight`, `on weekends or after sunset`, `weekends or evenings except tuesday`
 * brackets group mixed and/or: `(last day of the month or wednesday) and after 10pm` - without brackets `and` binds tighter than `or`, and the understanding line always shows the grouping it settled on
 

--- a/cronplus-when-gate.html
+++ b/cronplus-when-gate.html
@@ -645,6 +645,9 @@ copies or substantial portions of the Software.
             <code>moon azimuth between 60 and 90</code> - a compass bearing from North
             (0-360&deg;); only <code>between</code> is supported, and a range wraps through
             north when the first number is bigger, e.g. <code>between 350 and 10</code></li>
+        <li><b>Comparison symbols:</b> <code>&gt;</code> and <code>&lt;</code> work as symbols
+            wherever "above"/"below"/"more than"/"less than" already do, e.g.
+            <code>sun &gt; 30 degrees</code>, <code>moon &lt; 50% illuminated</code></li>
         <li><b>Combining:</b> <code>on weekdays and during daylight</code>,
             <code>on weekends or after sunset</code>,
             <code>weekends or evenings except tuesday</code> (an <code>except</code> clause

--- a/cronplus-when-gate.html
+++ b/cronplus-when-gate.html
@@ -641,6 +641,10 @@ copies or substantial portions of the Software.
             <code>sun is high</code> / <code>moon is high</code> (above 45&deg;),
             <code>sun is low</code> / <code>moon is low</code> (up, between 0&deg; and 15&deg;) -
             the understanding line always shows the exact thresholds</li>
+        <li><b>Sun/moon azimuth:</b> <code>sun azimuth is between 134 and 138 degrees</code>,
+            <code>moon azimuth between 60 and 90</code> - a compass bearing from North
+            (0-360&deg;); only <code>between</code> is supported, and a range wraps through
+            north when the first number is bigger, e.g. <code>between 350 and 10</code></li>
         <li><b>Combining:</b> <code>on weekdays and during daylight</code>,
             <code>on weekends or after sunset</code>,
             <code>weekends or evenings except tuesday</code> (an <code>except</code> clause

--- a/cronplus-when-gate.html
+++ b/cronplus-when-gate.html
@@ -594,7 +594,10 @@ copies or substantial portions of the Software.
             Monday and the last is Sunday - the understanding line always shows which day it resolved to)</li>
         <li><b>Months and dates:</b> <code>in december</code>, <code>june to august</code>,
             <code>on the 1st of the month</code>, <code>christmas day</code>, <code>halloween</code>,
-            <code>new years day</code>, <code>after march</code> / <code>before march</code>
+            <code>new years day</code>, <code>valentines day</code>, <code>groundhog day</code>,
+            <code>st patricks day</code>, <code>april fools day</code>, <code>earth day</code>,
+            <code>may day</code>, <code>boxing day</code> (all fixed, same everywhere - no moveable
+            feasts or country-varying rules), <code>after march</code> / <code>before march</code>
             (excludes march itself either way; <code>before january</code>/<code>after december</code>
             have no month left to name, so they're rejected rather than always false)</li>
         <li><b>Years:</b> <code>in 2027</code>, <code>2027 to 2029</code>, <code>january 2027</code>,
@@ -613,6 +616,10 @@ copies or substantial portions of the Software.
         <li><b>Clock time:</b> <code>between 9am and 5pm</code>, <code>from 09:00 to 17:30</code>,
             <code>before noon</code>, <code>after 10pm</code>, <code>between 10pm and 6am</code>
             (ranges that end at or before their start cross midnight; the end is exclusive)</li>
+        <li><b>Day parts:</b> <code>morning</code> (00:00-12:00), <code>afternoon</code> (12:00-18:00),
+            <code>evening</code> (18:00-24:00) - fixed clock hours, not solar; the understanding
+            line names the sun-relative equivalent instead (<code>dawn</code>/<code>sunrise</code>,
+            <code>afternoon sun</code>/<code>golden hour</code>, <code>dusk</code>/<code>twilight</code>)</li>
         <li><b>Minute of the hour:</b> <code>between 15 minutes and 30 minutes past the hour</code>,
             <code>from 0 minutes to 10 minutes</code>, <code>quarter past</code>, <code>half past</code>,
             <code>quarter to</code>, <code>ten past</code>, <code>5 to</code> (every hour).

--- a/cronplus-when-gate.html
+++ b/cronplus-when-gate.html
@@ -594,10 +594,13 @@ copies or substantial portions of the Software.
             Monday and the last is Sunday - the understanding line always shows which day it resolved to)</li>
         <li><b>Months and dates:</b> <code>in december</code>, <code>june to august</code>,
             <code>on the 1st of the month</code>, <code>christmas day</code>, <code>halloween</code>,
-            <code>new years day</code></li>
+            <code>new years day</code>, <code>after march</code> / <code>before march</code>
+            (excludes march itself either way; <code>before january</code>/<code>after december</code>
+            have no month left to name, so they're rejected rather than always false)</li>
         <li><b>Years:</b> <code>in 2027</code>, <code>2027 to 2029</code>, <code>january 2027</code>,
             <code>first monday of the year</code>, <code>2nd tuesday of 2028</code>,
-            <code>first monday of january</code>, <code>first/last day of the year</code></li>
+            <code>first monday of january</code>, <code>first/last day of the year</code>,
+            <code>after 2027</code> / <code>before 2027</code> (unbounded, unlike months)</li>
         <li><b>Even/odd:</b> <code>when day is odd</code> (the day of the month),
             <code>odd days</code>, <code>on even months</code>, <code>on even years</code>,
             <code>month is even</code></li>
@@ -646,8 +649,9 @@ copies or substantial portions of the Software.
             (0-360&deg;); only <code>between</code> is supported, and a range wraps through
             north when the first number is bigger, e.g. <code>between 350 and 10</code></li>
         <li><b>Comparison symbols:</b> <code>&gt;</code> and <code>&lt;</code> work as symbols
-            wherever "above"/"below"/"more than"/"less than" already do, e.g.
-            <code>sun &gt; 30 degrees</code>, <code>moon &lt; 50% illuminated</code></li>
+            for "above"/"below"/"more than"/"less than", e.g.
+            <code>sun &gt; 30 degrees</code>, <code>moon &lt; 50% illuminated</code>,
+            <code>&gt; 4pm</code> (same as <code>after 4pm</code>), <code>at least 4pm</code></li>
         <li><b>Combining:</b> <code>on weekdays and during daylight</code>,
             <code>on weekends or after sunset</code>,
             <code>weekends or evenings except tuesday</code> (an <code>except</code> clause

--- a/lib/when-gate-eval.js
+++ b/lib/when-gate-eval.js
@@ -96,8 +96,19 @@ function sunAltitude (ts, lat, lon) {
     return SunCalc.getPosition(new Date(ts), lat, lon).altitude // degrees (suncalc v2)
 }
 
+function sunAzimuth (ts, lat, lon) {
+    return SunCalc.getPosition(new Date(ts), lat, lon).azimuth // degrees, compass bearing from North (suncalc v2)
+}
+
 function sunDirection (ts, lat, lon) {
     return sunAltitude(ts + 60000, lat, lon) > sunAltitude(ts, lat, lon) ? 'rise' : 'fall'
+}
+
+// azimuth is a compass bearing (0-360, wraps at North) - "between 350 and 10"
+// spans through 360/0, so a plain low <= az <= high check only works when the
+// range doesn't cross north; low > high signals a wrapping range instead
+function inAzimuthRange (az, low, high) {
+    return low <= high ? (az >= low && az <= high) : (az >= low || az <= high)
 }
 
 // solar states by sun-altitude thresholds (polar safe - no event scanning):
@@ -442,6 +453,10 @@ function evalTerm (term, ctx) {
             }
             return { pass, detail: 'sun altitude is ' + alt.toFixed(1) + ' degrees' }
         }
+        case 'sunAzimuth': {
+            const az = sunAzimuth(ts, lat, lon)
+            return { pass: inAzimuthRange(az, term.low, term.high), detail: 'sun azimuth is ' + az.toFixed(1) + ' degrees' }
+        }
         case 'solarState': {
             const alt = sunAltitude(ts, lat, lon)
             let pass = term.states.some(function (s) { return solarStateMatch(s, alt) })
@@ -523,6 +538,10 @@ function evalTerm (term, ctx) {
                 pass = term.op === 'above' ? alt > term.degrees : alt <= term.degrees
             }
             return { pass, detail: 'moon altitude is ' + alt.toFixed(1) + ' degrees' }
+        }
+        case 'moonAzimuth': {
+            const az = SunCalc.getMoonPosition(new Date(ts), lat, lon).azimuth // degrees, compass bearing from North
+            return { pass: inAzimuthRange(az, term.low, term.high), detail: 'moon azimuth is ' + az.toFixed(1) + ' degrees' }
         }
         case 'moonPhase': {
             // "day before/after <phase>": the phase condition held offsetDays ago
@@ -758,6 +777,7 @@ module.exports = {
         getLocalParts,
         solarStateMatch,
         sunAltitude,
+        sunAzimuth,
         sunDirection,
         eventOccurrences
     }

--- a/lib/when-gate-eval.js
+++ b/lib/when-gate-eval.js
@@ -380,6 +380,10 @@ function evalTerm (term, ctx) {
         }
         case 'year': {
             const p = getLocalParts(ts, tz)
+            if (term.op) {
+                const pass = term.op === 'before' ? p.year < term.boundary : p.year > term.boundary
+                return { pass, detail: 'local year is ' + p.year }
+            }
             return { pass: term.years.indexOf(p.year) >= 0, detail: 'local year is ' + p.year }
         }
         case 'parity': {

--- a/resources/when-gate-lang.js
+++ b/resources/when-gate-lang.js
@@ -818,8 +818,14 @@
             case 'TO': // a LEADING range-word reads as "before": "until 6pm", "till sunset"
                 state.symbols[state.pos] = { type: 'BEFORE', raw: sym.raw }
                 return parseBeforeAfter(state)
+            // MORE/LESS as a LEADING symbol (not already consumed as a lookahead
+            // inside sun/moon altitude or moon illumination) are before/after for
+            // a time-ish target: "greater than 4pm" = after 4pm, not "ignore the
+            // comparison and match the exact minute 16:00"
             case 'BEFORE':
             case 'AFTER':
+            case 'MORE':
+            case 'LESS':
                 return parseBeforeAfter(state)
             case 'WITHIN':
                 return parseWithin(state)
@@ -1591,7 +1597,7 @@
 
     function parseBeforeAfter (state) {
         const opSym = peek(state)
-        const op = opSym.type === 'BEFORE' ? 'before' : 'after'
+        const op = (opSym.type === 'BEFORE' || opSym.type === 'LESS') ? 'before' : 'after'
         state.pos++
         const target = peek(state)
         if (target && (target.type === 'TIME' || target.type === 'TIMEWORD')) {
@@ -1615,6 +1621,27 @@
             const term = clone(target.term)
             term.source = opSym.raw + ' ' + target.raw
             return term
+        }
+        // "before march"/"after march": a plain month-list term excluding march
+        // itself either way, same shape "june to august" already produces so it
+        // combines/coalesces the same way. "before january"/"after december" has
+        // no month left to name - reject rather than emit an always-false term
+        if (target && target.type === 'MONTH') {
+            state.pos++
+            const months = op === 'before'
+                ? Array.from({ length: target.month - 1 }, function (_, i) { return i + 1 })
+                : Array.from({ length: 12 - target.month }, function (_, i) { return target.month + 1 + i })
+            if (!months.length) {
+                state.unmatched.push(opSym.raw + ' ' + target.raw)
+                return null
+            }
+            return { kind: 'month', months, source: opSym.raw + ' ' + target.raw }
+        }
+        // "before 2027"/"after 2027": years are unbounded, so (unlike months) this
+        // needs an open-ended form alongside the plain "years" list - see evalTerm
+        if (target && target.type === 'NUM' && !target.ordinal && isYearNumber(target.value)) {
+            state.pos++
+            return { kind: 'year', op, boundary: target.value, source: opSym.raw + ' ' + target.raw }
         }
         // minute-of-hour and anchored-time sub-conditions: "before quarter to
         // [the hour]", "after 20 past", "before quarter past five" (= before 05:15)
@@ -1724,7 +1751,7 @@
     // must never set-union with plain terms
     function coalescable (term) {
         return MUTUALLY_EXCLUSIVE[term.kind] && !term.negate && !term.last && !term.weekOrdinal &&
-            !term.month && !term.year && !term.firstCount && !term.lastCount && !term.scope
+            !term.month && !term.year && !term.firstCount && !term.lastCount && !term.scope && !term.op
     }
 
     // Within an AND group, positive same-kind day/month terms union together:
@@ -1903,6 +1930,10 @@
                 break
             }
             case 'year': {
+                if (term.op) {
+                    text = 'year is ' + term.op + ' ' + term.boundary
+                    break
+                }
                 const years = term.years
                 const contiguous = years.length > 2 && years[years.length - 1] - years[0] === years.length - 1
                 if (contiguous) {

--- a/resources/when-gate-lang.js
+++ b/resources/when-gate-lang.js
@@ -294,7 +294,7 @@
         const tokens = []
         const src = String(text || '').toLowerCase().replace(/[’‘`']/g, '')
         // longest alternatives first: time with am/pm or colon, percent, ordinal/number, word
-        const re = /(\d{1,2}):(\d{2})\s*(am|pm)?|(\d{1,2})(?:\.(\d{2}))?\s*(am|pm)|(\d+(?:\.\d+)?)\s*%|(\d+(?:\.\d+)?)(st|nd|rd|th)?|([a-z]+)|(,)|(-)|(\()|(\))/g
+        const re = /(\d{1,2}):(\d{2})\s*(am|pm)?|(\d{1,2})(?:\.(\d{2}))?\s*(am|pm)|(\d+(?:\.\d+)?)\s*%|(\d+(?:\.\d+)?)(st|nd|rd|th)?|([a-z]+)|(,)|(-)|(\()|(\))|(>)|(<)/g
         let m
         while ((m = re.exec(src)) !== null) {
             const raw = m[0].trim()
@@ -316,6 +316,10 @@
                 tokens.push({ type: 'lparen', raw })
             } else if (m[14] !== undefined) {
                 tokens.push({ type: 'rparen', raw })
+            } else if (m[15] !== undefined) {
+                tokens.push({ type: 'gt', raw })
+            } else if (m[16] !== undefined) {
+                tokens.push({ type: 'lt', raw })
             }
         }
         return tokens
@@ -403,6 +407,12 @@
             if (tok.type === 'dash') { symbols.push({ type: 'DASH', raw: tok.raw }); i++; continue }
             if (tok.type === 'lparen') { symbols.push({ type: 'LPAREN', raw: tok.raw }); i++; continue }
             if (tok.type === 'rparen') { symbols.push({ type: 'RPAREN', raw: tok.raw }); i++; continue }
+            // ">" / "<" are plain synonyms for "more than"/"less than", so they
+            // reuse the MORE/LESS symbol - every existing consumer that accepts
+            // ABOVE/BELOW (altitude, illumination) already accepts MORE/LESS
+            // too, so no other code needs to change for these to work
+            if (tok.type === 'gt') { symbols.push({ type: 'MORE', raw: tok.raw }); i++; continue }
+            if (tok.type === 'lt') { symbols.push({ type: 'LESS', raw: tok.raw }); i++; continue }
             if (tok.type === 'time') {
                 if (tok.minutes === null) { unmatched.push(tok.raw); i++; continue }
                 symbols.push({ type: 'TIME', minutes: tok.minutes, raw: tok.raw })

--- a/resources/when-gate-lang.js
+++ b/resources/when-gate-lang.js
@@ -24,7 +24,7 @@
     const MONTH_NAMES = ['', 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
 
     // Term kinds that cannot be computed without a latitude/longitude
-    const LOCATION_KINDS = ['solarState', 'sunDirection', 'sunAltitude', 'solarEvent', 'solarBetween', 'moonAltitude']
+    const LOCATION_KINDS = ['solarState', 'sunDirection', 'sunAltitude', 'sunAzimuth', 'solarEvent', 'solarBetween', 'moonAltitude', 'moonAzimuth']
 
     // ------------------------------------------------------------------
     // Vocabulary (data driven - new phrases are one-line additions)
@@ -154,6 +154,8 @@
         { words: ['deg'], sym: { type: 'DEG' } },
         { words: ['above'], sym: { type: 'ABOVE' } },
         { words: ['below'], sym: { type: 'BELOW' } },
+        // celestial azimuth: "sun azimuth is between 134 and 138 degrees"
+        { words: ['azimuth'], sym: { type: 'AZIMUTH' } },
         { words: ['sun', 'high'], sym: { type: 'TERM', term: { kind: 'sunAltitude', op: 'above', degrees: 45, label: 'high' } } },
         { words: ['sun', 'low'], sym: { type: 'TERM', term: { kind: 'sunAltitude', op: 'between', low: 0, high: 15, label: 'low' } } },
         { words: ['moon', 'high'], sym: { type: 'TERM', term: { kind: 'moonAltitude', op: 'above', degrees: 45, label: 'high' } } },
@@ -269,7 +271,7 @@
     // Words carrying no meaning of their own. Stripped before phrase matching.
     // 'is' is included, so "moon is visible" matches the ['moon','visible'] phrase.
     // 'at' is included: "at 9am" parses as a bare time, "at night" as the night state.
-    const NOISE_WORDS = ['only', 'just', 'when', 'whenever', 'if', 'the', 'on', 'in', 'is', 'it', 'its', 'was', 'are', 'be', 'during', 'a', 'an', 'at', 'whilst', 'while', 'time', 'times', 'every', 'each', 'them', 'those', 'their']
+    const NOISE_WORDS = ['only', 'just', 'when', 'whenever', 'if', 'the', 'on', 'in', 'is', 'it', 'its', 'was', 'are', 'be', 'during', 'a', 'an', 'at', 'whilst', 'while', 'time', 'times', 'every', 'each', 'them', 'those', 'their', 'altitude']
 
     // Single-word vocabulary for distance-1 fuzzy fallback (typo tolerance)
     const FUZZY_VOCAB = (function () {
@@ -538,7 +540,8 @@
     }
 
     // bare "sun" is Sunday only when it sits in a day list or range; it stays
-    // SUN_WORD before an altitude comparison ("sun is between 10 and 12 degrees")
+    // SUN_WORD before an altitude or azimuth comparison ("sun is between 10 and
+    // 12 degrees", "sun azimuth is between 134 and 138")
     function promoteSunWords (symbols, unmatched) {
         for (let i = 0; i < symbols.length; i++) {
             if (symbols[i].type !== 'SUN_WORD') { continue }
@@ -551,9 +554,9 @@
                 return s && (s.type === 'AND' || s.type === 'OR' || s.type === 'COMMA') && dayish(s2)
             }
             const altitudeish = function (s) {
-                return s && ['BETWEEN', 'ABOVE', 'BELOW', 'MORE', 'LESS'].indexOf(s.type) >= 0
+                return s && ['BETWEEN', 'ABOVE', 'BELOW', 'MORE', 'LESS', 'AZIMUTH'].indexOf(s.type) >= 0
             }
-            if (altitudeish(next)) { continue } // handled by parseCelestialAltitude
+            if (altitudeish(next)) { continue } // handled by parseCelestialAltitude/parseCelestialAzimuth
             if (dayish(prev) || dayish(next) || listish(prev, symbols[i - 2]) || listish(next, symbols[i + 2])) {
                 symbols[i] = { type: 'DAY', day: 0, raw: symbols[i].raw }
             } else {
@@ -835,6 +838,9 @@
             case 'MOON_WORD':
                 return parseMoonCondition(state)
             case 'SUN_WORD':
+                if (peek(state, 1) && peek(state, 1).type === 'AZIMUTH') {
+                    return parseCelestialAzimuth(state, 'sunAzimuth')
+                }
                 return parseCelestialAltitude(state, 'sunAltitude')
             default:
                 return null
@@ -883,6 +889,38 @@
             return null
         }
         state.unmatched.push(word.raw)
+        return null
+    }
+
+    function normalizeDeg (d) {
+        return ((d % 360) + 360) % 360
+    }
+
+    // "sun/moon azimuth [is] between 134 and 138 [degrees]". The leading
+    // SUN_WORD/MOON_WORD and the AZIMUTH symbol are both at the current position.
+    // Azimuth is a compass bearing (0-360, from North), so unlike altitude it
+    // wraps: "between 350 and 10" spans north through 360/0 (see evalTerm). Only
+    // "between" is supported - a bearing has no natural "above/below" the way
+    // altitude has a horizon.
+    function parseCelestialAzimuth (state, kind) {
+        const word = peek(state)
+        const azWord = peek(state, 1)
+        state.pos += 2
+        const bodyText = (kind === 'sunAzimuth' ? 'sun' : 'moon') + ' azimuth'
+        const cmp = peek(state)
+        if (cmp && cmp.type === 'BETWEEN') {
+            state.pos++
+            const low = parseDegreeValue(state)
+            if (peek(state) && (peek(state).type === 'AND' || peek(state).type === 'TO')) { state.pos++ }
+            const high = parseDegreeValue(state)
+            if (peek(state) && peek(state).type === 'DEG') { state.pos++ }
+            if (low !== null && high !== null) {
+                return { kind, op: 'between', low: normalizeDeg(low), high: normalizeDeg(high), source: bodyText + ' between ' + low + ' and ' + high + ' degrees' }
+            }
+            state.unmatched.push(word.raw + ' ' + azWord.raw + ' between')
+            return null
+        }
+        state.unmatched.push(word.raw + ' ' + azWord.raw)
         return null
     }
 
@@ -1626,6 +1664,10 @@
     function parseMoonCondition (state) {
         const start = peek(state)
         const cmp = peek(state, 1)
+        // azimuth: "moon azimuth is between 60 and 90 degrees"
+        if (cmp && cmp.type === 'AZIMUTH') {
+            return parseCelestialAzimuth(state, 'moonAzimuth')
+        }
         // illumination: "moon more than 50% illuminated"
         if (cmp && (cmp.type === 'MORE' || cmp.type === 'LESS')) {
             const pct = peek(state, 2)
@@ -1993,6 +2035,9 @@
                     text = 'sun altitude is ' + term.op + ' ' + term.degrees + ' degrees'
                 }
                 break
+            case 'sunAzimuth':
+                text = 'sun azimuth is between ' + term.low + ' and ' + term.high + ' degrees'
+                break
             case 'solarEvent': {
                 const label = EVENT_LABELS[term.event] || term.event
                 if (term.op === 'within') {
@@ -2020,6 +2065,9 @@
                 } else {
                     text = 'moon altitude is ' + term.op + ' ' + term.degrees + ' degrees'
                 }
+                break
+            case 'moonAzimuth':
+                text = 'moon azimuth is between ' + term.low + ' and ' + term.high + ' degrees'
                 break
             case 'moonPhase': {
                 if (term.offsetDays) { // "day before blue moon", "2 days after a full moon"
@@ -2149,9 +2197,11 @@
         solarState: 'Sun',
         sunDirection: 'Sun',
         sunAltitude: 'Sun',
+        sunAzimuth: 'Sun',
         solarEvent: 'Sun',
         solarBetween: 'Sun',
         moonAltitude: 'Moon',
+        moonAzimuth: 'Moon',
         moonPhase: 'Moon',
         moonIllumination: 'Moon'
     }
@@ -2203,9 +2253,11 @@
         'is night', 'during daylight', 'after dark', 'golden hour', 'sun rising', 'after sunset',
         'before sunrise', '2 hours after sunset', 'within 30 minutes of sunrise', 'between sunset and sunrise',
         'sun above 30 degrees', 'sun is between 10 and 12 degrees', 'sun is high',
+        'sun azimuth is between 134 and 138 degrees',
         // moon
         'when the moon is visible', 'full moon', 'blue moon', 'seasonal blue moon', 'day before blue moon',
         'moon is high', 'moon is 90% illuminated', 'moon more than 50% illuminated', 'new moon',
+        'moon azimuth is between 60 and 90 degrees',
         // combinations
         'on weekdays and during daylight', 'on weekends or after sunset', 'weekends or evenings except tuesday',
         '(last day of the month or wednesday) and after 10pm', 'every day'

--- a/resources/when-gate-lang.js
+++ b/resources/when-gate-lang.js
@@ -103,6 +103,31 @@
     // sym types produced: TERM (a ready term), SOLAR_AMBIG (state or event by
     // context, e.g. dawn/dusk), EVENT (solar event name), and keyword symbols.
     const PHRASES = [
+        // additional named dates (christmas/halloween/new year live in NAMED_DATES
+        // instead, being single bare words). Fixed month/day, same wherever
+        // observed - no moveable feasts (easter) or country-varying rules
+        // (thanksgiving, independence/labor day) belong here
+        { words: ['valentines', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 2, day: 14, name: 'valentines day' } } },
+        { words: ['valentines'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 2, day: 14, name: 'valentines day' } } },
+        { words: ['groundhog', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 2, day: 2, name: 'groundhog day' } } },
+        { words: ['groundhog'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 2, day: 2, name: 'groundhog day' } } },
+        // "patrick"/"fool" (dropped possessive) are listed explicitly rather than
+        // left to typo-correction: that only retries the word where phrase
+        // matching STARTS, so a typo further into a 3-word phrase strands the
+        // trailing word(s) to be misread on their own ("day" as daylight, "april"
+        // as the month) instead of being recovered
+        { words: ['st', 'patricks', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 3, day: 17, name: 'st patricks day' } } },
+        { words: ['st', 'patrick', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 3, day: 17, name: 'st patricks day' } } },
+        { words: ['saint', 'patricks', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 3, day: 17, name: 'st patricks day' } } },
+        { words: ['saint', 'patrick', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 3, day: 17, name: 'st patricks day' } } },
+        { words: ['april', 'fools', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 4, day: 1, name: 'april fools day' } } },
+        { words: ['april', 'fools'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 4, day: 1, name: 'april fools day' } } },
+        { words: ['april', 'fool', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 4, day: 1, name: 'april fools day' } } },
+        { words: ['april', 'fool'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 4, day: 1, name: 'april fools day' } } },
+        { words: ['earth', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 4, day: 22, name: 'earth day' } } },
+        { words: ['may', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 5, day: 1, name: 'may day' } } },
+        { words: ['boxing', 'day'], sym: { type: 'TERM', term: { kind: 'namedDate', month: 12, day: 26, name: 'boxing day' } } },
+
         // combinators / operators
         { words: ['but', 'not'], sym: { type: 'EXCEPT' } },
         { words: ['except'], sym: { type: 'EXCEPT' } },
@@ -238,10 +263,11 @@
         { words: ['midday'], sym: { type: 'TIMEWORD', minutes: 720 } },
         { words: ['midnight'], sym: { type: 'TIMEWORD', minutes: 0 } },
 
-        // clock-based day parts
-        { words: ['morning'], sym: { type: 'TERM', term: { kind: 'timeRange', style: 'before', startMin: 0, endMin: 720 } } },
-        { words: ['afternoon'], sym: { type: 'TERM', term: { kind: 'timeRange', style: 'between', startMin: 720, endMin: 1080 } } },
-        { words: ['evening'], sym: { type: 'TERM', term: { kind: 'solarEvent', event: 'sunset', op: 'after' } } },
+        // clock-based day parts (fixed hours, not solar - the understanding line
+        // points to the solar-relative words instead of guessing which one meant)
+        { words: ['morning'], sym: { type: 'TERM', term: { kind: 'timeRange', style: 'before', startMin: 0, endMin: 720, label: 'morning' } } },
+        { words: ['afternoon'], sym: { type: 'TERM', term: { kind: 'timeRange', style: 'between', startMin: 720, endMin: 1080, label: 'afternoon' } } },
+        { words: ['evening'], sym: { type: 'TERM', term: { kind: 'timeRange', style: 'between', startMin: 1080, endMin: 1440, label: 'evening' } } },
 
         // moon
         { words: ['moon', 'visible'], sym: { type: 'TERM', term: { kind: 'moonAltitude', op: 'above', degrees: 0 } } },
@@ -1482,6 +1508,15 @@
             state.pos += 2
             return { kind: 'solarBetween', from: eventName, to: endEv, source: raw + ' to ' + endSym.raw }
         }
+        // "to"/"until" was there, but the target is a duration (e.g. "golden
+        // hour", "twilight"), not an instant, so there is no usable endpoint -
+        // consume both sides and report the whole attempted range as unmatched,
+        // rather than silently falling back to the bare leading event and
+        // letting the endpoint drift off to be misread as its own clause
+        if (endSym) {
+            state.pos += 2
+            state.unmatched.push(raw + ' ' + joiner.raw + ' ' + endSym.raw)
+        }
         return null
     }
 
@@ -1550,14 +1585,17 @@
             state.unmatched.push(start.raw + ' ' + a.raw + ' minutes')
             return null
         }
-        // time range: between TIME and TIME
-        if (a && (a.type === 'TIME' || a.type === 'TIMEWORD' || (a.type === 'NUM' && !a.ordinal && a.value <= 23))) {
+        // time range: between TIME and TIME. A bare NUM only counts as an hour
+        // when it's a whole number (matches clockMinutesFromSym/consumeHourAnchor
+        // below) - a decimal like 2.2 is not a clock hour and must not silently
+        // become 132 minutes (02:12) via value * 60
+        if (a && (a.type === 'TIME' || a.type === 'TIMEWORD' || (a.type === 'NUM' && !a.ordinal && Number.isInteger(a.value) && a.value <= 23))) {
             const startMin = a.type === 'NUM' ? a.value * 60 : a.minutes
             state.pos++
             const joiner = peek(state)
             if (joiner && (joiner.type === 'AND' || joiner.type === 'TO' || joiner.type === 'DASH')) { state.pos++ }
             const b = peek(state)
-            if (b && (b.type === 'TIME' || b.type === 'TIMEWORD' || (b.type === 'NUM' && !b.ordinal && b.value <= 23))) {
+            if (b && (b.type === 'TIME' || b.type === 'TIMEWORD' || (b.type === 'NUM' && !b.ordinal && Number.isInteger(b.value) && b.value <= 23))) {
                 const endMin = b.type === 'NUM' ? b.value * 60 : b.minutes
                 state.pos++
                 return { kind: 'timeRange', style: 'between', startMin, endMin, source: start.raw + ' ' + a.raw + ' and ' + b.raw }
@@ -2040,6 +2078,12 @@
                     text = 'time is between ' + fmtMinutes(term.startMin) + ' and ' + fmtMinutes(term.endMin)
                     if (term.endMin <= term.startMin) { text += ' (overnight)' }
                 }
+                if (term.label) {
+                    // fixed clock hours, not solar - point at the sun-relative
+                    // words instead of guessing which one was meant
+                    const solarHints = { morning: 'dawn/sunrise', afternoon: 'afternoon sun/golden hour', evening: 'dusk/twilight' }
+                    text += ' (' + term.label + '; for sun-relative timing try ' + solarHints[term.label] + ')'
+                }
                 break
             case 'solarState': {
                 const labels = {
@@ -2286,7 +2330,8 @@
         'on the 1st of the month',
         // dates
         'christmas day', 'christmas eve', 'day before christmas', '4 days after christmas',
-        'within 2 days of christmas', 'new years day',
+        'within 2 days of christmas', 'new years day', 'valentines day', 'st patricks day',
+        'april fools day', 'earth day', 'may day', 'boxing day', 'groundhog day',
         // clock times
         'between 9am and 5pm', '10pm to 6am', 'before noon', 'after 10pm', 'until 6pm',
         'quarter past five', 'ten past', 'between 15 minutes and 30 minutes past the hour', '2 hours before noon',

--- a/test/when_gate_eval_spec.js
+++ b/test/when_gate_eval_spec.js
@@ -444,6 +444,46 @@ describe('when-gate-eval: sun/moon position', function () {
         r.pass.should.be.false()
         r.reasons[0].detail.should.match(/location/)
     })
+
+    it('azimuth ranges track suncalc (Newgrange midwinter sunrise, real-world regression)', function () {
+        // Newgrange, Ireland: the passage aligns with sunrise for a few mornings around
+        // the winter solstice, when azimuth is ~127-142 degrees and the sun has just
+        // cleared the horizon. This is the exact condition a user asked to express.
+        const NEWGRANGE = { lat: 53.6944, lon: -6.4756 }
+        const cond = 'sun azimuth is between 134 and 138 and sun altitude is above 0.5'
+        let aligned = null
+        for (let m = 0; m < 40 && !aligned; m++) {
+            const ts = Date.parse('2026-12-21T08:35:00Z') + m * 60000
+            const pos = SunCalc.getPosition(new Date(ts), NEWGRANGE.lat, NEWGRANGE.lon)
+            if (pos.azimuth >= 134 && pos.azimuth <= 138 && pos.altitude > 0.5) { aligned = ts }
+        }
+        should.exist(aligned, 'no aligned minute found in the scanned window')
+        evalText(cond, { ts: aligned, tz: 'UTC', ...NEWGRANGE }).pass.should.be.true()
+        evalText(cond, { ts: Date.parse('2026-12-21T12:00:00Z'), tz: 'UTC', ...NEWGRANGE }).pass.should.be.false() // solar noon: well past the alignment
+    })
+
+    it('moon azimuth ranges track suncalc', function () {
+        const ts = Date.parse('2026-01-15T22:00:00Z')
+        const az = SunCalc.getMoonPosition(new Date(ts), LONDON.lat, LONDON.lon).azimuth
+        evalText(`moon azimuth is between ${Math.floor(az) - 1} and ${Math.ceil(az) + 1} degrees`, { ts, tz, ...LONDON }).pass.should.be.true()
+        evalText('moon azimuth is between 0 and 1 degrees', { ts, tz, ...LONDON }).pass.should.equal(az <= 1)
+    })
+
+    it('azimuth "between" wraps through north (real high-latitude near-summer-solstice case)', function () {
+        // 65N, midsummer: pre-dawn sun azimuth swings into single digits (measured from
+        // north), the case a plain low<=az<=high check gets backwards
+        const ts = Date.parse('2026-06-21T00:30:00Z')
+        const pos = SunCalc.getPosition(new Date(ts), 65, 0)
+        pos.azimuth.should.be.below(20) // sanity check on the fixture itself
+        evalText('sun azimuth between 350 and 20', { ts, tz: 'UTC', lat: 65, lon: 0 }).pass.should.be.true()
+        evalText('sun azimuth between 20 and 350', { ts, tz: 'UTC', lat: 65, lon: 0 }).pass.should.be.false() // same bounds, not wrapping
+    })
+
+    it('azimuth conditions require a location', function () {
+        const r = evalText('sun azimuth is between 0 and 360', { ts: midsummerNoon, tz })
+        r.pass.should.be.false()
+        r.reasons[0].detail.should.match(/location/)
+    })
 })
 
 describe('when-gate-eval: minute of the hour', function () {

--- a/test/when_gate_eval_spec.js
+++ b/test/when_gate_eval_spec.js
@@ -45,6 +45,14 @@ describe('when-gate-eval: calendar terms', function () {
         evalText('on the 21st of the month', { ts: SUNDAY_NOON_UTC, tz: 'UTC' }).pass.should.be.true()
     })
 
+    it('"after march"/"before march" exclude march itself either way', function () {
+        evalText('after march', { ts: Date.parse('2026-04-01T00:00:00Z'), tz: 'UTC' }).pass.should.be.true()
+        evalText('after march', { ts: Date.parse('2026-03-31T23:59:59Z'), tz: 'UTC' }).pass.should.be.false()
+        evalText('before march', { ts: Date.parse('2026-02-28T00:00:00Z'), tz: 'UTC' }).pass.should.be.true()
+        evalText('before march', { ts: Date.parse('2026-03-01T00:00:00Z'), tz: 'UTC' }).pass.should.be.false()
+        evalText('> march', { ts: SUNDAY_NOON_UTC, tz: 'UTC' }).pass.should.be.true() // June
+    })
+
     it('"every day" always passes', function () {
         evalText('every day', { ts: SUNDAY_NOON_UTC }).pass.should.be.true()
     })
@@ -309,6 +317,15 @@ describe('when-gate-eval: years', function () {
     it('year ranges', function () {
         evalText('2027 to 2029', { ts: Date.parse('2028-06-15T12:00:00Z'), tz }).pass.should.be.true()
         evalText('2027 to 2029', { ts: Date.parse('2026-06-15T12:00:00Z'), tz }).pass.should.be.false()
+    })
+
+    it('"after 2027"/"before 2027" exclude 2027 itself either way (unbounded)', function () {
+        evalText('after 2027', { ts: Date.parse('2028-01-01T00:00:00Z'), tz }).pass.should.be.true()
+        evalText('after 2027', { ts: Date.parse('2027-12-31T23:59:59Z'), tz }).pass.should.be.false()
+        evalText('> 2027', { ts: Date.parse('2100-01-01T00:00:00Z'), tz }).pass.should.be.true() // genuinely unbounded
+        evalText('before 2027', { ts: Date.parse('2026-12-31T23:59:59Z'), tz }).pass.should.be.true()
+        evalText('before 2027', { ts: Date.parse('2027-01-01T00:00:00Z'), tz }).pass.should.be.false()
+        evalText('< 2027', { ts: Date.parse('1970-01-01T00:00:00Z'), tz }).pass.should.be.true()
     })
 
     it('1st monday of the year (Jan 1 2026 is a Thursday, so 5 Jan)', function () {

--- a/test/when_gate_eval_spec.js
+++ b/test/when_gate_eval_spec.js
@@ -45,6 +45,13 @@ describe('when-gate-eval: calendar terms', function () {
         evalText('on the 21st of the month', { ts: SUNDAY_NOON_UTC, tz: 'UTC' }).pass.should.be.true()
     })
 
+    it('matches the other fixed named dates', function () {
+        evalText('valentines day', { ts: Date.parse('2027-02-14T09:00:00Z'), tz: 'UTC' }).pass.should.be.true()
+        evalText('may day', { ts: Date.parse('2027-05-01T09:00:00Z'), tz: 'UTC' }).pass.should.be.true()
+        evalText('boxing day', { ts: Date.parse('2026-12-26T09:00:00Z'), tz: 'UTC' }).pass.should.be.true()
+        evalText('boxing day', { ts: Date.parse('2026-12-25T09:00:00Z'), tz: 'UTC' }).pass.should.be.false()
+    })
+
     it('"after march"/"before march" exclude march itself either way', function () {
         evalText('after march', { ts: Date.parse('2026-04-01T00:00:00Z'), tz: 'UTC' }).pass.should.be.true()
         evalText('after march', { ts: Date.parse('2026-03-31T23:59:59Z'), tz: 'UTC' }).pass.should.be.false()
@@ -88,6 +95,21 @@ describe('when-gate-eval: time ranges (Europe/London, GMT in January)', function
     it('respects DST local clock (2026-06-21T11:30Z is 12:30 BST)', function () {
         evalText('before noon', { ts: at('2026-06-21T11:30:00Z'), tz }).pass.should.be.false()
         evalText('before noon', { ts: at('2026-06-21T10:30:00Z'), tz }).pass.should.be.true()
+    })
+
+    it('evening is fixed clock hours (18:00-24:00), not tied to real sunset - and no longer needs a location', function () {
+        evalText('evening', { ts: at('2026-06-21T18:00:00Z'), tz: 'UTC' }).pass.should.be.true()
+        evalText('evening', { ts: at('2026-06-21T23:59:00Z'), tz: 'UTC' }).pass.should.be.true()
+        evalText('evening', { ts: at('2026-06-22T00:00:00Z'), tz: 'UTC' }).pass.should.be.false()
+        evalText('evening', { ts: at('2026-06-21T17:59:00Z'), tz: 'UTC' }).pass.should.be.false()
+        // no lat/lon supplied at all - would have errored under the old solar-based definition
+        should.exist(evalText('evening', { ts: at('2026-06-21T19:00:00Z'), tz: 'UTC' }).pass)
+    })
+
+    it('"daylight and sun setting" is the closest solar equivalent of "afternoon" - "sun setting" alone runs past sunset into the night', function () {
+        evalText('sun setting', { ts: at('2026-06-21T23:00:00Z'), tz: 'UTC', ...LONDON }).pass.should.be.true() // well after sunset, still "setting"
+        evalText('daylight and sun setting', { ts: at('2026-06-21T15:00:00Z'), tz: 'UTC', ...LONDON }).pass.should.be.true() // solar afternoon
+        evalText('daylight and sun setting', { ts: at('2026-06-21T23:00:00Z'), tz: 'UTC', ...LONDON }).pass.should.be.false() // night now, not afternoon
     })
 })
 
@@ -462,17 +484,20 @@ describe('when-gate-eval: sun/moon position', function () {
         r.reasons[0].detail.should.match(/location/)
     })
 
-    it('azimuth ranges track suncalc (Newgrange midwinter sunrise, real-world regression)', function () {
+    it('azimuth+altitude ranges track suncalc (Newgrange midwinter sunrise, real-world regression)', function () {
         // Newgrange, Ireland: the passage aligns with sunrise for a few mornings around
-        // the winter solstice, when azimuth is ~127-142 degrees and the sun has just
-        // cleared the horizon. This is the exact condition a user asked to express.
+        // the winter solstice, when azimuth is 134-138 degrees and altitude is
+        // 0.9-2.2 degrees (just clear of the horizon). This is the exact condition
+        // a user asked to express, and must be written with "sun" on both clauses -
+        // "and its altitude..." has no sun/moon context of its own (see the
+        // when-gate-lang "between" regression test).
         const NEWGRANGE = { lat: 53.6944, lon: -6.4756 }
-        const cond = 'sun azimuth is between 134 and 138 and sun altitude is above 0.5'
+        const cond = 'sun azimuth is between 134 and 138 and sun altitude is between 0.9 and 2.2'
         let aligned = null
         for (let m = 0; m < 40 && !aligned; m++) {
             const ts = Date.parse('2026-12-21T08:35:00Z') + m * 60000
             const pos = SunCalc.getPosition(new Date(ts), NEWGRANGE.lat, NEWGRANGE.lon)
-            if (pos.azimuth >= 134 && pos.azimuth <= 138 && pos.altitude > 0.5) { aligned = ts }
+            if (pos.azimuth >= 134 && pos.azimuth <= 138 && pos.altitude >= 0.9 && pos.altitude <= 2.2) { aligned = ts }
         }
         should.exist(aligned, 'no aligned minute found in the scanned window')
         evalText(cond, { ts: aligned, tz: 'UTC', ...NEWGRANGE }).pass.should.be.true()

--- a/test/when_gate_lang_spec.js
+++ b/test/when_gate_lang_spec.js
@@ -634,6 +634,24 @@ describe('when-gate-lang parse: sun/moon position', function () {
         onlyTerm('moon below -5 degrees').should.have.properties({ kind: 'moonAltitude', op: 'below', degrees: -5 })
     })
 
+    it('">" and "<" are accepted as symbols for "above"/"below" wherever they already work', function () {
+        onlyTerm('sun > 30 degrees').should.have.properties({ kind: 'sunAltitude', op: 'above', degrees: 30 })
+        onlyTerm('moon < -5 degrees').should.have.properties({ kind: 'moonAltitude', op: 'below', degrees: -5 })
+        onlyTerm('moon > 50% illuminated').should.have.properties({ kind: 'moonIllumination', op: 'gt', fraction: 0.5 })
+        lang.parse('sun > 30 degrees').description.should.equal(lang.parse('sun above 30 degrees').description)
+    })
+
+    it('"greater than"/"less than" already worked as above/below synonyms before ">"/"<" existed', function () {
+        onlyTerm('sun greater than 30 degrees').should.have.properties({ kind: 'sunAltitude', op: 'above', degrees: 30 })
+        onlyTerm('sun less than 30 degrees').should.have.properties({ kind: 'sunAltitude', op: 'below', degrees: 30 })
+    })
+
+    it('">" is not a silent no-op when the surrounding phrase does not support it (azimuth: only "between")', function () {
+        const r = lang.parse('sun azimuth > 30 degrees')
+        r.ok.should.be.false()
+        r.unmatched.should.containEql('>')
+    })
+
     it('parses negative between range "sun is between -6 and 0 degrees"', function () {
         const term = onlyTerm('sun is between -6 and 0 degrees')
         term.low.should.equal(-6)

--- a/test/when_gate_lang_spec.js
+++ b/test/when_gate_lang_spec.js
@@ -658,6 +658,38 @@ describe('when-gate-lang parse: sun/moon position', function () {
         onlyTerm('sat and sun').days.should.eql([0, 6])
         onlyTerm('sun above horizon').kind.should.equal('sunAltitude') // phrase unchanged
     })
+
+    it('parses "sun azimuth is between 134 and 138 degrees"', function () {
+        const term = onlyTerm('sun azimuth is between 134 and 138 degrees')
+        term.should.have.properties({ kind: 'sunAzimuth', op: 'between', low: 134, high: 138 })
+        lang.parse('sun azimuth is between 134 and 138 degrees').description.should.equal('sun azimuth is between 134 and 138 degrees')
+    })
+
+    it('parses "moon azimuth between 60 and 90" without "is"', function () {
+        onlyTerm('moon azimuth between 60 and 90').should.have.properties({ kind: 'moonAzimuth', op: 'between', low: 60, high: 90 })
+    })
+
+    it('negative and out-of-range azimuth values normalise into 0-360', function () {
+        onlyTerm('sun azimuth between -10 and 10').should.have.properties({ low: 350, high: 10 })
+        onlyTerm('sun azimuth is between 400 and 410').should.have.properties({ low: 40, high: 50 })
+    })
+
+    it('azimuth combines with altitude and other clauses via "and"', function () {
+        const terms = onlyGroupTerms('sun azimuth is between 134 and 138 and sun altitude is above 0.5')
+        terms.should.have.length(2)
+        terms[0].kind.should.equal('sunAzimuth')
+        terms[1].should.have.properties({ kind: 'sunAltitude', op: 'above', degrees: 0.5 })
+    })
+
+    it('bare "sun azimuth" or an unsupported "above/below" form fails to parse (only "between" is supported)', function () {
+        lang.parse('sun azimuth').ok.should.be.false()
+        lang.parse('sun azimuth above 30 degrees').ok.should.be.false()
+    })
+
+    it('bare "sun"/"moon" before azimuth are not mistaken for Sunday or moon phase', function () {
+        onlyTerm('sun azimuth is between 1 and 2 degrees').kind.should.equal('sunAzimuth')
+        onlyTerm('moon azimuth is between 1 and 2 degrees').kind.should.equal('moonAzimuth')
+    })
 })
 
 describe('when-gate-lang parse: minute of the hour', function () {

--- a/test/when_gate_lang_spec.js
+++ b/test/when_gate_lang_spec.js
@@ -148,9 +148,63 @@ describe('when-gate-lang parse: months and dates', function () {
         term.month.should.equal(1)
         term.day.should.equal(1)
     })
+
+    it('parses the other fixed, unambiguous named dates', function () {
+        onlyTerm("valentine's day").should.have.properties({ kind: 'namedDate', month: 2, day: 14 })
+        onlyTerm('valentines').should.have.properties({ kind: 'namedDate', month: 2, day: 14 })
+        onlyTerm('groundhog day').should.have.properties({ kind: 'namedDate', month: 2, day: 2 })
+        onlyTerm("st patrick's day").should.have.properties({ kind: 'namedDate', month: 3, day: 17 })
+        onlyTerm('saint patricks day').should.have.properties({ kind: 'namedDate', month: 3, day: 17 })
+        onlyTerm('april fools day').should.have.properties({ kind: 'namedDate', month: 4, day: 1 })
+        onlyTerm('earth day').should.have.properties({ kind: 'namedDate', month: 4, day: 22 })
+        onlyTerm('may day').should.have.properties({ kind: 'namedDate', month: 5, day: 1 })
+        onlyTerm('boxing day').should.have.properties({ kind: 'namedDate', month: 12, day: 26 })
+    })
+
+    it('"may day" does not steal bare "may" from the month grammar', function () {
+        onlyTerm('in may').should.have.properties({ kind: 'month', months: [5] })
+        onlyTerm('may').should.have.properties({ kind: 'month', months: [5] })
+    })
+
+    it('a holiday name needing "day" to mean anything does not match on its own (e.g. "boxing")', function () {
+        lang.parse('boxing').ok.should.be.false()
+    })
+
+    it('the generic "eve" mechanism applies to the new named dates too', function () {
+        lang.parse('valentines day eve').description.should.equal('date is 13 February (valentines eve)')
+        lang.parse('boxing day eve').description.should.equal('date is 25 December (boxing eve)')
+    })
+
+    it('regression: a dropped possessive mid-phrase used to strand the trailing word to be misread on its own', function () {
+        // "st patrick day" (missing the 's') used to: fuzzy-correct 'patrick' to
+        // 'patricks' (a real, accurate hint) but too late to help, since retry only
+        // checks the corrected word as its OWN phrase start - stranding 'day' to
+        // separately match the unrelated single-word "daylight" phrase, and for
+        // "april fool day" stranding 'april' to match the month on its own
+        onlyTerm('st patrick day').should.have.properties({ kind: 'namedDate', month: 3, day: 17 })
+        onlyTerm('saint patrick day').should.have.properties({ kind: 'namedDate', month: 3, day: 17 })
+        onlyTerm('april fool day').should.have.properties({ kind: 'namedDate', month: 4, day: 1 })
+        onlyTerm('april fool').should.have.properties({ kind: 'namedDate', month: 4, day: 1 })
+        lang.parse('st patrick day').warnings.should.be.empty()
+        lang.parse('st patrick day').unmatched.should.be.empty()
+    })
 })
 
 describe('when-gate-lang parse: time ranges', function () {
+    it('morning/afternoon/evening are all fixed clock hours, not solar', function () {
+        onlyTerm('morning').should.have.properties({ kind: 'timeRange', style: 'before', startMin: 0, endMin: 720 })
+        onlyTerm('afternoon').should.have.properties({ kind: 'timeRange', style: 'between', startMin: 720, endMin: 1080 })
+        onlyTerm('evening').should.have.properties({ kind: 'timeRange', style: 'between', startMin: 1080, endMin: 1440 })
+        // none of the three need a location any more (evening used to, tied to real sunset)
+        lang.requiresLocation(lang.parse('evening').ast).should.be.false()
+    })
+
+    it('the understanding line points morning/afternoon/evening at their solar-relative equivalents', function () {
+        lang.parse('morning').description.should.match(/for sun-relative timing try dawn\/sunrise/)
+        lang.parse('afternoon').description.should.match(/for sun-relative timing try afternoon sun\/golden hour/)
+        lang.parse('evening').description.should.match(/for sun-relative timing try dusk\/twilight/)
+    })
+
     it('parses "weekdays between 9am and 5pm"', function () {
         const terms = onlyGroupTerms('weekdays between 9am and 5pm')
         terms.should.have.length(2)
@@ -245,6 +299,19 @@ describe('when-gate-lang parse: time ranges', function () {
         const term = onlyTerm('from 09:00 to 17:30')
         term.startMin.should.equal(540)
         term.endMin.should.equal(1050)
+    })
+
+    it('regression: a bare decimal in "between X and Y" is not silently mistaken for an hour count', function () {
+        // "between 0.9 and 2.2" used to slip past the bare-hour branch (which only
+        // meant to accept whole hours like "between 9 and 17") and multiply the
+        // decimal by 60 as if it were a fractional hour - 2.2 became 132 minutes
+        // (02:12). A degree/percent/any-other-decimal range with no sun/moon
+        // context to claim it should fail to parse, not silently become a time.
+        const r = lang.parse('between 0.9 and 2.2')
+        r.ok.should.be.false()
+        r.unmatched.should.containEql('0.9')
+        // whole-hour bare numbers must still work exactly as before
+        onlyTerm('between 9 and 17').should.have.properties({ kind: 'timeRange', style: 'between', startMin: 540, endMin: 1020 })
     })
 
     it('parses "at 9.30pm" (dot separator) as an exact-minute condition', function () {
@@ -363,6 +430,23 @@ describe('when-gate-lang parse: solar', function () {
         lang.parse('10pm to sunrise').unmatched.should.have.length(0)
         lang.parse('sunrise until 6pm').unmatched.should.have.length(0)
         onlyTerm('sunrise').op.should.equal('within') // standalone event unchanged
+    })
+
+    it('regression: "X until <duration>" reports the whole range as unmatched instead of silently splitting into an unrelated "and"', function () {
+        // "golden hour"/"twilight"/"night" are durations (an altitude band), not
+        // an instant, so they can't be a range endpoint - this used to drop
+        // "until" and let the duration word drift off to be misread as its own,
+        // unrelated clause ("it is dawn AND it is golden hour")
+        for (const phrase of ['dawn until golden hour', 'dawn until civil twilight', 'dawn until twilight', 'dawn until night']) {
+            const r = lang.parse(phrase)
+            r.ok.should.be.true()
+            r.description.should.equal('it is dawn (twilight, sun rising)')
+            r.unmatched.should.eql([phrase])
+        }
+        // a typo on "until" doesn't change the outcome - the target is the real problem
+        lang.parse('dawn untill golden hour').unmatched.should.eql(['dawn untill golden hour'])
+        // valid ranges (an instant on both sides) are unaffected
+        lang.parse('dawn until noon').unmatched.should.be.empty()
     })
 })
 

--- a/test/when_gate_lang_spec.js
+++ b/test/when_gate_lang_spec.js
@@ -182,6 +182,65 @@ describe('when-gate-lang parse: time ranges', function () {
         term.startMin.should.equal(1320)
     })
 
+    it('regression: "greater than"/">"/"at least"/"over" no longer silently collapse a time into an exact minute', function () {
+        // this used to drop the comparison as unmatched and parse the bare time
+        // as an exact-minute match instead - "any time after 4pm" silently became
+        // "only during the single minute of 4:00pm", with a much less visible warning
+        const afterFour = { kind: 'timeRange', style: 'after', startMin: 960, endMin: 1440 }
+        onlyTerm('greater than 4pm').should.have.properties(afterFour)
+        onlyTerm('> 4pm').should.have.properties(afterFour)
+        onlyTerm('at least 4pm').should.have.properties(afterFour)
+        onlyTerm('over 4pm').should.have.properties(afterFour)
+        const beforeNine = { kind: 'timeRange', style: 'before', startMin: 0, endMin: 540 }
+        onlyTerm('less than 9am').should.have.properties(beforeNine)
+        onlyTerm('< 9am').should.have.properties(beforeNine)
+        onlyTerm('at most 9am').should.have.properties(beforeNine)
+        onlyTerm('under 9am').should.have.properties(beforeNine)
+        lang.parse('greater than 4pm').unmatched.should.be.empty()
+        // symbol and word forms must be indistinguishable downstream (same AST, same description)
+        lang.parse('> 4pm').description.should.equal(lang.parse('after 4pm').description)
+        lang.parse('< 9am').description.should.equal(lang.parse('before 9am').description)
+    })
+
+    it('"more than"/"less than"/">"/"<" also read as after/before for a solar event or minute-of-hour target', function () {
+        onlyTerm('more than sunset').should.have.properties({ kind: 'solarEvent', event: 'sunset', op: 'after' })
+        onlyTerm('> sunset').should.have.properties({ kind: 'solarEvent', event: 'sunset', op: 'after' })
+        onlyTerm('less than sunrise').should.have.properties({ kind: 'solarEvent', event: 'sunrise', op: 'before' })
+        onlyTerm('< sunrise').should.have.properties({ kind: 'solarEvent', event: 'sunrise', op: 'before' })
+        onlyTerm('less than quarter past five').should.have.properties({ kind: 'timeRange', style: 'before', endMin: 315 })
+        onlyTerm('> 20 past').should.have.properties({ kind: 'minuteOfHour', style: 'after', startMin: 20 })
+        onlyTerm('< quarter to').should.have.properties({ kind: 'minuteOfHour', style: 'before', startMin: 45 })
+    })
+
+    it('">"/"before"/"after" work for months, excluding the named month either way', function () {
+        onlyTerm('> march').should.have.properties({ kind: 'month', months: [4, 5, 6, 7, 8, 9, 10, 11, 12] })
+        onlyTerm('after march').should.have.properties({ kind: 'month', months: [4, 5, 6, 7, 8, 9, 10, 11, 12] })
+        onlyTerm('< march').should.have.properties({ kind: 'month', months: [1, 2] })
+        onlyTerm('before march').should.have.properties({ kind: 'month', months: [1, 2] })
+        lang.parse('> march').description.should.equal(lang.parse('after march').description)
+        // no month is left to name before january / after december - reject, don't guess
+        lang.parse('before january').ok.should.be.false()
+        lang.parse('after december').ok.should.be.false()
+        // negation composes for free - it's a plain month term under the hood
+        onlyTerm('not after march').should.have.properties({ kind: 'month', months: [4, 5, 6, 7, 8, 9, 10, 11, 12], negate: true })
+    })
+
+    it('">"/"before"/"after" work for years, which (unlike months) are unbounded', function () {
+        onlyTerm('> 2027').should.have.properties({ kind: 'year', op: 'after', boundary: 2027 })
+        onlyTerm('after 2027').should.have.properties({ kind: 'year', op: 'after', boundary: 2027 })
+        onlyTerm('< 2027').should.have.properties({ kind: 'year', op: 'before', boundary: 2027 })
+        onlyTerm('before 2027').should.have.properties({ kind: 'year', op: 'before', boundary: 2027 })
+        lang.parse('> 2027').description.should.equal(lang.parse('after 2027').description)
+    })
+
+    it('day-of-month still has no ">"/"before"/"after" concept - the comparison is honestly reported as unmatched, not silently dropped', function () {
+        // unlike the time-of-day bug, this was never silently misleading: the
+        // comparison word has always shown up in `unmatched` rather than vanishing
+        const r = lang.parse('> the 15th')
+        r.description.should.equal('day of the month is 15')
+        r.unmatched.should.containEql('>')
+    })
+
     it('parses "from 09:00 to 17:30"', function () {
         const term = onlyTerm('from 09:00 to 17:30')
         term.startMin.should.equal(540)


### PR DESCRIPTION
These landed as separate pieces during testing, but they're all the same kind of thing: gaps and silent misparses in the when gate condition language that should have been correct from the first release, not follow-up work. Treating the whole branch as fixes rather than new scope creep.

**Filling gaps that should have been there from the start**

* Sun/moon azimuth: `sun azimuth is between 134 and 138 degrees` - a compass bearing from North (0-360°), wraps through north (`between 350 and 10`)
* `>`/`<` as symbols for above/below/more than/less than, everywhere those already worked (altitude, illumination, clock time)
* `before`/`after` for months and years: `after march`, `before 2027` - months exclude the named month either way; years are open-ended (unbounded, unlike months)
* Seven more fixed, same-everywhere named dates alongside christmas/halloween/new year: valentines day, groundhog day, st patricks day, april fools day, earth day, may day, boxing day. Deliberately excludes movable feasts (easter) and country-varying ones (thanksgiving, independence/labor day) - see commit message for why.

**Fixes: silent misparses**

* `greater than`/`less than`/`>`/`<` didn't work for clock time at all. `greater than 4pm` dropped the comparison and matched the *exact minute* 16:00 instead of "any time after 4pm" - a whole-day range silently collapsed to one minute. Now routes through the same before/after logic as the word forms.
* A bare decimal in a context-free `between X and Y` (nothing claiming it as sun/moon altitude) was read as a fractional hour and multiplied by 60 - `between 0.9 and 2.2` became `00:54 and 02:12`. Now rejected honestly instead of guessing.
* `X until/to <duration>` (`golden hour`, `twilight`, `civil twilight`, `night`) silently dropped the comparison and let the duration drift off as an unrelated clause - `dawn until golden hour` read as `dawn AND golden hour`. Durations aren't instants, so they were never valid range endpoints; now the whole attempted range is reported as unmatched.
* A typo landing on a non-first word of a multi-word phrase stranded the trailing word(s) to be misread on their own - `st patrick day` (missing the possessive) resolved to the unrelated "daylight" phrase via the orphaned "day". Fixed for the two known cases by accepting `patrick`/`fool` as direct alternate spellings.
* `evening` was solar (open-ended from actual sunset) while `morning`/`afternoon` were fixed clock hours - the odd one out, and the only one of the three that required a location. `evening` is now `18:00-24:00` like its siblings; the understanding line for all three now names the solar-relative equivalent (`dawn`/`sunrise`, `afternoon sun`/`golden hour`, `dusk`/`twilight`) instead of leaving it to guesswork.

**Testing**

* 360 tests (up from 328 at the start of this branch), all passing
* Lint and build clean
* Sun/moon position verified against real solar data (Newgrange's midwinter sunrise alignment), not synthetic numbers alone
